### PR TITLE
build: 빌드 시 에러 발생하는 부분 수정

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build/
+.gradle/
+.git/

--- a/Dockerfile.Build
+++ b/Dockerfile.Build
@@ -1,24 +1,39 @@
 # Build stage
 FROM gradle:8.10.2-jdk17 AS builder
 
-WORKDIR /home/gradle/src
-COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /workspace
 
-USER gradle
-RUN gradle build --no-daemon -x test
+COPY gradle gradle
+COPY gradlew .
+COPY build.gradle.kts settings.gradle.kts ./
+
+ENV GRADLE_USER_HOME=/root/.gradle
+
+RUN chmod +x ./gradlew
+RUN ./gradlew --no-daemon dependencies
+
+COPY . .
+
+RUN ./gradlew --no-daemon clean build -x test
 
 # Runtime stage
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jre-noble
 
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+# 최소 유틸 설치
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends tini curl \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+COPY --from=builder /workspace/build/libs/*.jar /app.jar
 
-COPY --from=builder /home/gradle/src/build/libs/*.jar app.jar
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+UseStringDeduplication -XX:+AlwaysActAsServer"
+ENV SPRING_PROFILES_ACTIVE=prod
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
CD 파이프라인 실행 시 에러가 발생힙나다. ([참고](https://github.com/khu-khlug/sight-spring-backend/actions/runs/17185523592/job/48753968322)) 이를 해결합니다.

추가적으로, runtime stage에서 jdk 이미지 대신 jre를 사용하도록 수정합니다.