### PR TITLE
build: 잘못된 자바 옵션 및 jar 위치 수정

### DIFF
--- a/Dockerfile.Build
+++ b/Dockerfile.Build
@@ -25,9 +25,9 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY --from=builder /workspace/build/libs/*.jar /app.jar
+COPY --from=builder /workspace/build/libs/*.jar app.jar
 
-ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+UseStringDeduplication -XX:+AlwaysActAsServer"
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+UseStringDeduplication"
 ENV SPRING_PROFILES_ACTIVE=prod
 
 EXPOSE 8080


### PR DESCRIPTION
- 잘못된 자바 옵션(`AlwaysActAsServer`)를 제거합니다. (hallucination)
- jar 경로를 잘못 지정한 문제를 수정합니다. (`/app.jar` to `app.jar`)