### PR TITLE
fix: 플래그 형태의 필드는 명시적으로 tinyint를 사용하도록 수정

### DIFF
--- a/src/main/kotlin/com/sight/domain/Member.kt
+++ b/src/main/kotlin/com/sight/domain/Member.kt
@@ -57,10 +57,10 @@ data class Member(
     @Column(name = "expoint", nullable = false)
     val expoint: Long = 0L,
 
-    @Column(name = "active", nullable = false)
+    @Column(name = "active", nullable = false, columnDefinition = "TINYINT(1)")
     val active: Boolean = false,
 
-    @Column(name = "manager", nullable = false)
+    @Column(name = "manager", nullable = false, columnDefinition = "TINYINT(1)")
     val manager: Boolean = false,
 
     @Column(name = "slack", length = 100)


### PR DESCRIPTION
- 플래그 형태의 필드는 명시적으로 tinyint 타입을 사용하도록 수정하였습니다.
- schema validation 시 단순 `Boolean`으로 사용하면 validation 에러가 발생하여 application이 정상적으로 켜지지 않는 문제가 있었습니다.