### PR TITLE
feat: 디스코드 연동 정보 조회 api 구현 및 api 접두사 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@
   - 디스코드 이벤트 컨트롤러: `com.sight.controllers.discord` 패키지
   - **중요**: 컨트롤러에서는 비즈니스 로직을 작성하지 않고, DTO validation과 응답 DTO 생성만 담당
   - 모든 비즈니스 로직은 Service 계층에 위임
+  - **API 경로 규칙**: 클래스 레벨 `@RequestMapping` 사용 금지. 각 메서드의 매핑 어노테이션에 전체 경로 직접 지정 (예: `@GetMapping("/users/@me/profile")`)
 - **core**: 횡단 관심사와 관련된 모든 코드 (데이터베이스 연결, 인증/인가, 디스코드 클라이언트 등)
 - **domain**: 도메인 모델과 도메인 서비스 (순수 함수, side-effect 없음)
   - 멤버 도메인: `com.sight.domain.member` 패키지

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,14 +46,17 @@
 ### 디렉토리별 책임
 - **config**: 애플리케이션 설정과 관련된 내용. 로직이 들어가면 안 됨
 - **controllers**: 외부에서 들어오는 모든 요청(HTTP, 디스코드 이벤트 등)을 최초로 받는 곳
-  - REST API 컨트롤러: `com.sight.controllers.api` 패키지
+  - REST API 컨트롤러: `com.sight.controllers.http` 패키지
   - 디스코드 이벤트 컨트롤러: `com.sight.controllers.discord` 패키지
-  - API 엔드포인트는 `/api` 접두사 사용 (예: `/api/ping`)
+  - **중요**: 컨트롤러에서는 비즈니스 로직을 작성하지 않고, DTO validation과 응답 DTO 생성만 담당
+  - 모든 비즈니스 로직은 Service 계층에 위임
 - **core**: 횡단 관심사와 관련된 모든 코드 (데이터베이스 연결, 인증/인가, 디스코드 클라이언트 등)
 - **domain**: 도메인 모델과 도메인 서비스 (순수 함수, side-effect 없음)
   - 멤버 도메인: `com.sight.domain.member` 패키지
 - **repository**: 데이터 접근을 위한 리포지토리 인터페이스
 - **service**: side-effect가 발생할 수 있는 로직 및 애플리케이션 처리 흐름 제어 (clean architecture의 application 계층)
+  - 컨트롤러에서 호출되는 모든 비즈니스 로직을 담당
+  - 아무리 간단한 로직이라도 Service 계층에서 처리
 
 ### 의존성 방향
 - 일반적인 로직 처리 흐름: `controllers` → `service` → `domain`

--- a/src/main/kotlin/com/sight/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sight/config/SecurityConfig.kt
@@ -34,7 +34,7 @@ class SecurityConfig {
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
                 auth
-                    .requestMatchers("/api/ping", "/actuator/**", "/api/test/public").permitAll()
+                    .requestMatchers("/ping", "/actuator/**", "/test/public").permitAll()
                     .anyRequest().authenticated()
             }
             .addFilterBefore(cookieAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/src/main/kotlin/com/sight/controllers/http/PingController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/PingController.kt
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping
 class PingController {
     @GetMapping("/ping")
     fun ping(): String {

--- a/src/main/kotlin/com/sight/controllers/http/PingController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/PingController.kt
@@ -1,11 +1,9 @@
 package com.sight.controllers.http
 
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping
 class PingController {
     @GetMapping("/ping")
     fun ping(): String {

--- a/src/main/kotlin/com/sight/controllers/http/TestController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/TestController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/test")
+@RequestMapping("/test")
 class TestController {
     @GetMapping("/public")
     fun publicEndpoint(): String {

--- a/src/main/kotlin/com/sight/controllers/http/TestController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/TestController.kt
@@ -4,25 +4,23 @@ import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/test")
 class TestController {
-    @GetMapping("/public")
+    @GetMapping("/test/public")
     fun publicEndpoint(): String {
         return "This is a public endpoint"
     }
 
     @Auth([UserRole.USER, UserRole.MANAGER])
-    @GetMapping("/protected")
+    @GetMapping("/test/protected")
     fun protectedEndpoint(requester: Requester): String {
         return "Hello user ${requester.userId} with role ${requester.role}"
     }
 
     @Auth([UserRole.MANAGER])
-    @GetMapping("/admin")
+    @GetMapping("/test/admin")
     fun adminOnlyEndpoint(requester: Requester): String {
         return "Admin access for user ${requester.userId}"
     }

--- a/src/main/kotlin/com/sight/controllers/http/UserController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/UserController.kt
@@ -1,0 +1,32 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.GetDiscordIntegrationResponse
+import com.sight.core.auth.Auth
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
+import com.sight.service.UserDiscordService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+@RestController
+@RequestMapping("/users")
+class UserController(
+    private val userDiscordService: UserDiscordService,
+) {
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @GetMapping("/@me/discord-integration")
+    fun getCurrentUserDiscordIntegration(requester: Requester): GetDiscordIntegrationResponse {
+        val integration =
+            userDiscordService.getDiscordIntegration(requester.userId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "아직 디스코드와 연동하지 않았습니다")
+
+        return GetDiscordIntegrationResponse(
+            id = integration.id,
+            discordUserId = integration.discordUserId,
+            createdAt = integration.createdAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/UserController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/UserController.kt
@@ -5,10 +5,8 @@ import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
 import com.sight.service.UserDiscordService
-import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.server.ResponseStatusException
 
 @RestController
 class UserController(
@@ -17,9 +15,7 @@ class UserController(
     @Auth([UserRole.USER, UserRole.MANAGER])
     @GetMapping("/users/@me/discord-integration")
     fun getCurrentUserDiscordIntegration(requester: Requester): GetDiscordIntegrationResponse {
-        val integration =
-            userDiscordService.getDiscordIntegration(requester.userId)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "아직 디스코드와 연동하지 않았습니다")
+        val integration = userDiscordService.getDiscordIntegration(requester.userId)
 
         return GetDiscordIntegrationResponse(
             id = integration.id,

--- a/src/main/kotlin/com/sight/controllers/http/UserController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/UserController.kt
@@ -7,17 +7,15 @@ import com.sight.core.auth.UserRole
 import com.sight.service.UserDiscordService
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 
 @RestController
-@RequestMapping("/users")
 class UserController(
     private val userDiscordService: UserDiscordService,
 ) {
     @Auth([UserRole.USER, UserRole.MANAGER])
-    @GetMapping("/@me/discord-integration")
+    @GetMapping("/users/@me/discord-integration")
     fun getCurrentUserDiscordIntegration(requester: Requester): GetDiscordIntegrationResponse {
         val integration =
             userDiscordService.getDiscordIntegration(requester.userId)

--- a/src/main/kotlin/com/sight/controllers/http/dto/GetDiscordIntegrationResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/GetDiscordIntegrationResponse.kt
@@ -1,0 +1,9 @@
+package com.sight.controllers.http.dto
+
+import java.time.LocalDateTime
+
+data class GetDiscordIntegrationResponse(
+    val id: String,
+    val discordUserId: String,
+    val createdAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/sight/service/UserDiscordService.kt
+++ b/src/main/kotlin/com/sight/service/UserDiscordService.kt
@@ -1,0 +1,14 @@
+package com.sight.service
+
+import com.sight.domain.discord.DiscordIntegration
+import com.sight.repository.DiscordIntegrationRepository
+import org.springframework.stereotype.Service
+
+@Service
+class UserDiscordService(
+    private val discordIntegrationRepository: DiscordIntegrationRepository,
+) {
+    fun getDiscordIntegration(userId: Long): DiscordIntegration? {
+        return discordIntegrationRepository.findByUserId(userId)
+    }
+}

--- a/src/main/kotlin/com/sight/service/UserDiscordService.kt
+++ b/src/main/kotlin/com/sight/service/UserDiscordService.kt
@@ -2,13 +2,16 @@ package com.sight.service
 
 import com.sight.domain.discord.DiscordIntegration
 import com.sight.repository.DiscordIntegrationRepository
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
 
 @Service
 class UserDiscordService(
     private val discordIntegrationRepository: DiscordIntegrationRepository,
 ) {
-    fun getDiscordIntegration(userId: Long): DiscordIntegration? {
+    fun getDiscordIntegration(userId: Long): DiscordIntegration {
         return discordIntegrationRepository.findByUserId(userId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "아직 디스코드와 연동하지 않았습니다")
     }
 }

--- a/src/test/kotlin/com/sight/controller/http/PingControllerTest.kt
+++ b/src/test/kotlin/com/sight/controller/http/PingControllerTest.kt
@@ -16,7 +16,7 @@ class PingControllerTest {
 
     @Test
     fun `ping API는 pong을 반환한다`() {
-        mockMvc.perform(get("/api/ping"))
+        mockMvc.perform(get("/ping"))
             .andExpect(status().isOk)
             .andExpect(content().string("pong"))
     }

--- a/src/test/kotlin/com/sight/service/UserDiscordServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/UserDiscordServiceTest.kt
@@ -3,11 +3,13 @@ package com.sight.service
 import com.sight.domain.discord.DiscordIntegration
 import com.sight.repository.DiscordIntegrationRepository
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class UserDiscordServiceTest {
     private val discordIntegrationRepository = mock<DiscordIntegrationRepository>()
@@ -34,15 +36,16 @@ class UserDiscordServiceTest {
     }
 
     @Test
-    fun `디스코드 연동 정보가 없으면 null을 반환한다`() {
+    fun `디스코드 연동 정보가 없으면 404 예외를 던진다`() {
         // given
         val userId = 123L
         given(discordIntegrationRepository.findByUserId(userId)).willReturn(null)
 
-        // when
-        val result = userDiscordService.getDiscordIntegration(userId)
-
-        // then
-        assertNull(result)
+        // when & then
+        val exception =
+            assertThrows<ResponseStatusException> {
+                userDiscordService.getDiscordIntegration(userId)
+            }
+        assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
     }
 }

--- a/src/test/kotlin/com/sight/service/UserDiscordServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/UserDiscordServiceTest.kt
@@ -1,0 +1,48 @@
+package com.sight.service
+
+import com.sight.domain.discord.DiscordIntegration
+import com.sight.repository.DiscordIntegrationRepository
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UserDiscordServiceTest {
+    private val discordIntegrationRepository = mock<DiscordIntegrationRepository>()
+    private val userDiscordService = UserDiscordService(discordIntegrationRepository)
+
+    @Test
+    fun `사용자 ID로 디스코드 연동 정보를 조회한다`() {
+        // given
+        val userId = 123L
+        val integration =
+            DiscordIntegration(
+                id = "test-id",
+                userId = userId,
+                discordUserId = "discord-123",
+                createdAt = LocalDateTime.of(2024, 1, 1, 0, 0, 0),
+            )
+        given(discordIntegrationRepository.findByUserId(userId)).willReturn(integration)
+
+        // when
+        val result = userDiscordService.getDiscordIntegration(userId)
+
+        // then
+        assertEquals(integration, result)
+    }
+
+    @Test
+    fun `디스코드 연동 정보가 없으면 null을 반환한다`() {
+        // given
+        val userId = 123L
+        given(discordIntegrationRepository.findByUserId(userId)).willReturn(null)
+
+        // when
+        val result = userDiscordService.getDiscordIntegration(userId)
+
+        // then
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
- 디스코드 연동 정보 조회 API를 구현합니다.
- 모든 API에서 `/api` 접두사를 제거합니다.