### PR TITLE
fix: 디스코드 연동 정보의 유저 id가 스키마 유효성 확인에 실패한 문제 수정

### DIFF
--- a/src/main/kotlin/com/sight/domain/discord/DiscordIntegration.kt
+++ b/src/main/kotlin/com/sight/domain/discord/DiscordIntegration.kt
@@ -21,7 +21,7 @@ data class DiscordIntegration(
     val id: String,
 
     @Column(name = "user_id", nullable = false)
-    val userId: Long,
+    val userId: Int,
 
     @Column(name = "discord_user_id", length = 32, nullable = false)
     val discordUserId: String,


### PR DESCRIPTION
- `discord_integration` 테이블의 `user_id` 컬럼이 데이터베이스에서는 `int` 유형으로 되어 있으나 엔티티 정의는 `Long`으로 되어, schema validation에서 실패하는 문제를 수정합니다.
- `Long`을 `Int`로 수정합니다.