### PR TITLE
fix: 데이터베이스에 정의된 테이블 스키마와 member entity 정의가 맞지 않는 문제 수정

### DIFF
--- a/src/main/kotlin/com/sight/domain/member/Member.kt
+++ b/src/main/kotlin/com/sight/domain/member/Member.kt
@@ -33,7 +33,7 @@ data class Member(
     @Column(name = "grade", nullable = false)
     val grade: Long = 0L,
 
-    @Column(name = "state", nullable = false, columnDefinition = "INT")
+    @Column(name = "state", nullable = false, columnDefinition = "bigint")
     val studentStatus: StudentStatus,
 
     @Column(name = "email", length = 255)


### PR DESCRIPTION
- 데이터베이스에 정의된 테이블 스키마와 member entity의 `state` 컬럼 정의가 맞지 않는 문제를 수정합니다.