### PR TITLE
feat: 디스코드 연동 url 발급 api 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/UserController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/UserController.kt
@@ -2,6 +2,7 @@ package com.sight.controllers.http
 
 import com.sight.controllers.http.dto.CallbackDiscordIntegrationRequest
 import com.sight.controllers.http.dto.GetDiscordIntegrationResponse
+import com.sight.controllers.http.dto.IssueDiscordIntegrationUrlResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
@@ -45,5 +47,13 @@ class UserController(
         return ResponseEntity.status(HttpStatus.FOUND)
             .location(URI.create("https://app.khlug.org/member/integrate-discord"))
             .build()
+    }
+
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @PostMapping("/users/@me/discord-integration/issue-url")
+    fun issueDiscordIntegrationUrl(requester: Requester): IssueDiscordIntegrationUrlResponse {
+        val url = userDiscordService.issueDiscordIntegrationUrl(requester.userId)
+
+        return IssueDiscordIntegrationUrlResponse(url)
     }
 }

--- a/src/main/kotlin/com/sight/controllers/http/dto/IssueDiscordIntegrationUrlResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/IssueDiscordIntegrationUrlResponse.kt
@@ -1,0 +1,5 @@
+package com.sight.controllers.http.dto
+
+data class IssueDiscordIntegrationUrlResponse(
+    val url: String,
+)

--- a/src/main/kotlin/com/sight/core/discord/DiscordOAuth2Adapter.kt
+++ b/src/main/kotlin/com/sight/core/discord/DiscordOAuth2Adapter.kt
@@ -4,4 +4,6 @@ interface DiscordOAuth2Adapter {
     suspend fun getAccessToken(code: String): String
 
     suspend fun getCurrentUserId(accessToken: String): String
+
+    fun createOAuth2Url(state: String): String
 }

--- a/src/main/kotlin/com/sight/core/discord/HttpDiscordOAuth2Adapter.kt
+++ b/src/main/kotlin/com/sight/core/discord/HttpDiscordOAuth2Adapter.kt
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.server.ResponseStatusException
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 @Component
@@ -105,6 +107,24 @@ class HttpDiscordOAuth2Adapter(
                 throw ResponseStatusException(HttpStatus.BAD_REQUEST, "디스코드 사용자 정보 조회에 실패했습니다", e)
             }
         }
+
+    override fun createOAuth2Url(state: String): String {
+        val params =
+            mapOf(
+                "client_id" to clientId,
+                "redirect_uri" to redirectUri,
+                "response_type" to "code",
+                "scope" to "identify",
+                "state" to state,
+            )
+
+        val queryString =
+            params.entries.joinToString("&") { (key, value) ->
+                "$key=${URLEncoder.encode(value, StandardCharsets.UTF_8)}"
+            }
+
+        return "https://discord.com/oauth2/authorize?$queryString"
+    }
 
     private data class TokenResponse(
         @field:JsonProperty("access_token")

--- a/src/main/kotlin/com/sight/service/UserDiscordService.kt
+++ b/src/main/kotlin/com/sight/service/UserDiscordService.kt
@@ -53,4 +53,9 @@ class UserDiscordService(
 
         discordMemberService.reflectUserInfoToDiscordUser(userId)
     }
+
+    fun issueDiscordIntegrationUrl(userId: Long): String {
+        val state = discordStateGenerator.generate(userId)
+        return discordOAuth2Adapter.createOAuth2Url(state)
+    }
 }

--- a/src/test/kotlin/com/sight/service/UserDiscordServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/UserDiscordServiceTest.kt
@@ -59,4 +59,23 @@ class UserDiscordServiceTest {
             }
         assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
     }
+
+    @Test
+    fun `디스코드 연동 URL을 발급한다`() {
+        // given
+        val userId = 123L
+        val state = "generated-state"
+        val expectedUrl =
+            "https://discord.com/oauth2/authorize?" +
+                "client_id=test&redirect_uri=http%3A//localhost%3A8080/callback&response_type=code&scope=identify&state=generated-state"
+
+        given(discordStateGenerator.generate(userId)).willReturn(state)
+        given(discordOAuth2Adapter.createOAuth2Url(state)).willReturn(expectedUrl)
+
+        // when
+        val result = userDiscordService.issueDiscordIntegrationUrl(userId)
+
+        // then
+        assertEquals(expectedUrl, result)
+    }
 }


### PR DESCRIPTION
- 디스코드 연동 url 발급 api를 구현합니다.
- 기존 구현을 그대로 가져옵니다.