### PR TITLE
fix: enum에 대한 converter 구현

### DIFF
--- a/src/main/kotlin/com/sight/domain/member/Member.kt
+++ b/src/main/kotlin/com/sight/domain/member/Member.kt
@@ -1,6 +1,7 @@
 package com.sight.domain.member
 
 import jakarta.persistence.Column
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
@@ -33,7 +34,8 @@ data class Member(
     @Column(name = "grade", nullable = false)
     val grade: Long = 0L,
 
-    @Column(name = "state", nullable = false, columnDefinition = "bigint")
+    @Column(name = "state", nullable = false, columnDefinition = "TINYINT")
+    @Convert(converter = StudentStatusConverter::class)
     val studentStatus: StudentStatus,
 
     @Column(name = "email", length = 255)
@@ -58,6 +60,7 @@ data class Member(
     val expoint: Long = 0L,
 
     @Column(name = "active", nullable = false, columnDefinition = "TINYINT")
+    @Convert(converter = UserStatusConverter::class)
     val status: UserStatus,
 
     @Column(name = "manager", nullable = false, columnDefinition = "TINYINT")

--- a/src/main/kotlin/com/sight/domain/member/Member.kt
+++ b/src/main/kotlin/com/sight/domain/member/Member.kt
@@ -34,7 +34,7 @@ data class Member(
     @Column(name = "grade", nullable = false)
     val grade: Long = 0L,
 
-    @Column(name = "state", nullable = false, columnDefinition = "TINYINT")
+    @Column(name = "state", nullable = false, columnDefinition = "bigint")
     @Convert(converter = StudentStatusConverter::class)
     val studentStatus: StudentStatus,
 

--- a/src/main/kotlin/com/sight/domain/member/StudentStatusConverter.kt
+++ b/src/main/kotlin/com/sight/domain/member/StudentStatusConverter.kt
@@ -1,0 +1,17 @@
+package com.sight.domain.member
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter(autoApply = true)
+class StudentStatusConverter : AttributeConverter<StudentStatus, Int> {
+    override fun convertToDatabaseColumn(attribute: StudentStatus?): Int? {
+        return attribute?.code
+    }
+
+    override fun convertToEntityAttribute(dbData: Int?): StudentStatus? {
+        if (dbData == null) return null
+        return StudentStatus.entries.find { it.code == dbData }
+            ?: throw IllegalArgumentException("유효하지 않은 StudentStatus 코드: $dbData")
+    }
+}

--- a/src/main/kotlin/com/sight/domain/member/UserStatusConverter.kt
+++ b/src/main/kotlin/com/sight/domain/member/UserStatusConverter.kt
@@ -1,0 +1,17 @@
+package com.sight.domain.member
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter(autoApply = true)
+class UserStatusConverter : AttributeConverter<UserStatus, Int> {
+    override fun convertToDatabaseColumn(attribute: UserStatus?): Int? {
+        return attribute?.code?.toInt()
+    }
+
+    override fun convertToEntityAttribute(dbData: Int?): UserStatus? {
+        if (dbData == null) return null
+        return UserStatus.entries.find { it.code == dbData.toLong() }
+            ?: throw IllegalArgumentException("유효하지 않은 UserStatus 코드: $dbData")
+    }
+}

--- a/src/test/kotlin/com/sight/domain/member/StudentStatusConverterTest.kt
+++ b/src/test/kotlin/com/sight/domain/member/StudentStatusConverterTest.kt
@@ -1,0 +1,45 @@
+package com.sight.domain.member
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class StudentStatusConverterTest {
+    private val converter = StudentStatusConverter()
+
+    @Test
+    fun `모든 StudentStatus enum 값이 올바른 코드로 변환된다`() {
+        assertEquals(-1, converter.convertToDatabaseColumn(StudentStatus.UNITED))
+        assertEquals(0, converter.convertToDatabaseColumn(StudentStatus.ABSENCE))
+        assertEquals(1, converter.convertToDatabaseColumn(StudentStatus.UNDERGRADUATE))
+        assertEquals(2, converter.convertToDatabaseColumn(StudentStatus.GRADUATE))
+    }
+
+    @Test
+    fun `null 값은 null로 변환된다`() {
+        assertNull(converter.convertToDatabaseColumn(null))
+    }
+
+    @Test
+    fun `모든 유효한 코드가 올바른 StudentStatus enum으로 변환된다`() {
+        assertEquals(StudentStatus.UNITED, converter.convertToEntityAttribute(-1))
+        assertEquals(StudentStatus.ABSENCE, converter.convertToEntityAttribute(0))
+        assertEquals(StudentStatus.UNDERGRADUATE, converter.convertToEntityAttribute(1))
+        assertEquals(StudentStatus.GRADUATE, converter.convertToEntityAttribute(2))
+    }
+
+    @Test
+    fun `null 코드는 null로 변환된다`() {
+        assertNull(converter.convertToEntityAttribute(null))
+    }
+
+    @Test
+    fun `존재하지 않는 코드는 예외를 발생시킨다`() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                converter.convertToEntityAttribute(999)
+            }
+        assertEquals("유효하지 않은 StudentStatus 코드: 999", exception.message)
+    }
+}

--- a/src/test/kotlin/com/sight/domain/member/UserStatusConverterTest.kt
+++ b/src/test/kotlin/com/sight/domain/member/UserStatusConverterTest.kt
@@ -1,0 +1,43 @@
+package com.sight.domain.member
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UserStatusConverterTest {
+    private val converter = UserStatusConverter()
+
+    @Test
+    fun `모든 UserStatus enum 값이 올바른 코드로 변환된다`() {
+        assertEquals(-1, converter.convertToDatabaseColumn(UserStatus.INACTIVE))
+        assertEquals(0, converter.convertToDatabaseColumn(UserStatus.UNAUTHORIZED))
+        assertEquals(1, converter.convertToDatabaseColumn(UserStatus.ACTIVE))
+    }
+
+    @Test
+    fun `null 값은 null로 변환된다`() {
+        assertNull(converter.convertToDatabaseColumn(null))
+    }
+
+    @Test
+    fun `모든 유효한 코드가 올바른 UserStatus enum으로 변환된다`() {
+        assertEquals(UserStatus.INACTIVE, converter.convertToEntityAttribute(-1))
+        assertEquals(UserStatus.UNAUTHORIZED, converter.convertToEntityAttribute(0))
+        assertEquals(UserStatus.ACTIVE, converter.convertToEntityAttribute(1))
+    }
+
+    @Test
+    fun `null 코드는 null로 변환된다`() {
+        assertNull(converter.convertToEntityAttribute(null))
+    }
+
+    @Test
+    fun `존재하지 않는 코드는 예외를 발생시킨다`() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                converter.convertToEntityAttribute(999)
+            }
+        assertEquals("유효하지 않은 UserStatus 코드: 999", exception.message)
+    }
+}


### PR DESCRIPTION
- enum에 대한 converter를 구현합니다.
- 기존에는 converter가 없어 기본값인 0으로 설정되는 문제가 있었고, 이에 따라 디스코드 역할이 적절하게 부여되지 못하는 문제가 있었습니다.