### PR TITLE
feat: 그룹 디스코드 채널 정보 조회 internal api 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/InternalGroupController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/InternalGroupController.kt
@@ -1,0 +1,30 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.GetGroupDiscordChannelResponse
+import com.sight.core.auth.Auth
+import com.sight.core.auth.UserRole
+import com.sight.service.GroupDiscordChannelService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class InternalGroupController(
+    private val groupDiscordChannelService: GroupDiscordChannelService,
+) {
+    @Auth(roles = [UserRole.SYSTEM])
+    @GetMapping("/internal/groups/{groupId}/discord-channel")
+    fun getGroupDiscordChannel(
+        @PathVariable groupId: Long,
+    ): GetGroupDiscordChannelResponse {
+        val groupDiscordChannel = groupDiscordChannelService.getDiscordChannelByGroupId(groupId)
+
+        return GetGroupDiscordChannelResponse(
+            id = groupDiscordChannel.id,
+            groupId = groupDiscordChannel.groupId,
+            discordChannelId = groupDiscordChannel.discordChannelId,
+            createdAt = groupDiscordChannel.createdAt,
+            updatedAt = groupDiscordChannel.updatedAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/dto/GetGroupDiscordChannelResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/GetGroupDiscordChannelResponse.kt
@@ -1,0 +1,11 @@
+package com.sight.controllers.http.dto
+
+import java.time.LocalDateTime
+
+data class GetGroupDiscordChannelResponse(
+    val id: String,
+    val groupId: Long,
+    val discordChannelId: String,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/sight/service/GroupDiscordChannelService.kt
+++ b/src/main/kotlin/com/sight/service/GroupDiscordChannelService.kt
@@ -89,6 +89,12 @@ class GroupDiscordChannelService(
         )
     }
 
+    @Transactional(readOnly = true)
+    fun getDiscordChannelByGroupId(groupId: Long): GroupDiscordChannel {
+        return groupDiscordChannelRepository.findByGroupId(groupId)
+            ?: throw NotFoundException("해당 그룹의 디스코드 채널이 존재하지 않습니다")
+    }
+
     private fun validateMemberAddPermission(
         group: com.sight.domain.group.Group,
         memberId: Long,

--- a/src/test/kotlin/com/sight/service/GroupDiscordChannelServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/GroupDiscordChannelServiceTest.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.willReturn
+import java.time.LocalDateTime
 import java.util.Optional
 import kotlin.test.assertEquals
 
@@ -135,6 +136,39 @@ class GroupDiscordChannelServiceTest {
 
         assertThrows<UnprocessableEntityException> {
             groupDiscordChannelService.createDiscordChannel(groupId, masterId)
+        }
+    }
+
+    @Test
+    fun `그룹 ID로 디스코드 채널 정보를 조회한다`() {
+        val groupId = 1L
+        val groupDiscordChannel =
+            GroupDiscordChannel(
+                id = "test-ulid",
+                groupId = groupId,
+                discordChannelId = "1234567890",
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now(),
+            )
+
+        given(groupDiscordChannelRepository.findByGroupId(groupId)).willReturn(groupDiscordChannel)
+
+        val result = groupDiscordChannelService.getDiscordChannelByGroupId(groupId)
+
+        assertEquals(groupDiscordChannel.id, result.id)
+        assertEquals(groupId, result.groupId)
+        assertEquals("1234567890", result.discordChannelId)
+        verify(groupDiscordChannelRepository).findByGroupId(groupId)
+    }
+
+    @Test
+    fun `존재하지 않는 그룹의 디스코드 채널 조회 시 NotFoundException이 발생한다`() {
+        val groupId = 1L
+
+        given(groupDiscordChannelRepository.findByGroupId(groupId)).willReturn(null)
+
+        assertThrows<NotFoundException> {
+            groupDiscordChannelService.getDiscordChannelByGroupId(groupId)
         }
     }
 }


### PR DESCRIPTION
- 그룹 디스코드 채널 정보 조회 internal api를 구현합니다.
- laravel 서버에서 사용하기 위함입니다.