### PR TITLE
feat: 현재 유저 정보 조회 api 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/UserController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/UserController.kt
@@ -1,12 +1,14 @@
 package com.sight.controllers.http
 
 import com.sight.controllers.http.dto.CallbackDiscordIntegrationRequest
+import com.sight.controllers.http.dto.GetCurrentUserResponse
 import com.sight.controllers.http.dto.GetDiscordIntegrationResponse
 import com.sight.controllers.http.dto.IssueDiscordIntegrationUrlResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
 import com.sight.service.UserDiscordService
+import com.sight.service.UserService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -20,7 +22,24 @@ import java.net.URI
 @RestController
 class UserController(
     private val userDiscordService: UserDiscordService,
+    private val userService: UserService,
 ) {
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @GetMapping("/users/@me")
+    fun getCurrentUser(requester: Requester): GetCurrentUserResponse {
+        val member = userService.getMemberById(requester.userId)
+
+        return GetCurrentUserResponse(
+            id = member.id,
+            name = member.name,
+            manager = member.manager,
+            status = member.status,
+            studentStatus = member.studentStatus,
+            createdAt = member.createdAt,
+            updatedAt = member.updatedAt,
+        )
+    }
+
     @Auth([UserRole.USER, UserRole.MANAGER])
     @GetMapping("/users/@me/discord-integration")
     fun getCurrentUserDiscordIntegration(requester: Requester): GetDiscordIntegrationResponse {

--- a/src/main/kotlin/com/sight/controllers/http/dto/GetCurrentUserResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/GetCurrentUserResponse.kt
@@ -1,0 +1,15 @@
+package com.sight.controllers.http.dto
+
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
+import java.time.LocalDateTime
+
+data class GetCurrentUserResponse(
+    val id: Long,
+    val name: String,
+    val manager: Boolean,
+    val status: UserStatus,
+    val studentStatus: StudentStatus,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/sight/service/UserService.kt
+++ b/src/main/kotlin/com/sight/service/UserService.kt
@@ -1,17 +1,27 @@
 package com.sight.service
 
+import com.sight.core.exception.NotFoundException
+import com.sight.domain.member.Member
 import com.sight.repository.DiscordIntegrationRepository
+import com.sight.repository.MemberRepository
 import org.springframework.stereotype.Service
 
 @Service
 class UserService(
     private val discordIntegrationRepository: DiscordIntegrationRepository,
     private val discordMemberService: DiscordMemberService,
+    private val memberRepository: MemberRepository,
 ) {
     fun applyUserInfoToEnteredDiscordUser(discordUserId: String) {
         val discordIntegration = discordIntegrationRepository.findByDiscordUserId(discordUserId) ?: return
 
         val userId = discordIntegration.userId
         discordMemberService.reflectUserInfoToDiscordUser(userId)
+    }
+
+    fun getMemberById(userId: Long): Member {
+        return memberRepository.findById(userId).orElseThrow {
+            NotFoundException("사용자를 찾을 수 없습니다")
+        }
     }
 }

--- a/src/test/kotlin/com/sight/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/UserServiceTest.kt
@@ -1,0 +1,76 @@
+package com.sight.service
+
+import com.sight.core.exception.NotFoundException
+import com.sight.domain.member.Member
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
+import com.sight.repository.DiscordIntegrationRepository
+import com.sight.repository.MemberRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import java.util.Optional
+import kotlin.test.assertEquals
+
+class UserServiceTest {
+    private val discordIntegrationRepository: DiscordIntegrationRepository = mock()
+    private val discordMemberService: DiscordMemberService = mock()
+    private val memberRepository: MemberRepository = mock()
+    private lateinit var userService: UserService
+
+    @BeforeEach
+    fun setUp() {
+        userService =
+            UserService(
+                discordIntegrationRepository = discordIntegrationRepository,
+                discordMemberService = discordMemberService,
+                memberRepository = memberRepository,
+            )
+    }
+
+    @Test
+    fun `getMemberById는 존재하는 사용자를 반환한다`() {
+        // given
+        val userId = 1L
+        val member =
+            Member(
+                id = userId,
+                name = "testuser",
+                admission = "20",
+                realname = "테스트 사용자",
+                college = "소프트웨어융합학과",
+                grade = 3L,
+                studentStatus = StudentStatus.UNDERGRADUATE,
+                email = "test@example.com",
+                status = UserStatus.ACTIVE,
+                khuisauthAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now(),
+                createdAt = LocalDateTime.now(),
+                lastLogin = LocalDateTime.now(),
+                lastEnter = LocalDateTime.now(),
+            )
+        whenever(memberRepository.findById(userId)).thenReturn(Optional.of(member))
+
+        // when
+        val result = userService.getMemberById(userId)
+
+        // then
+        assertEquals(member, result)
+    }
+
+    @Test
+    fun `getMemberById는 존재하지 않는 사용자일 때 NotFoundException을 발생시킨다`() {
+        // given
+        val userId = 999L
+        whenever(memberRepository.findById(userId)).thenReturn(Optional.empty())
+
+        // when & then
+        val exception =
+            assertThrows<NotFoundException> {
+                userService.getMemberById(userId)
+            }
+    }
+}


### PR DESCRIPTION
- 현재 유저의 정보를 조회하는 API를 구현합니다.
- 운영진 여부 판단을 위해 구현하였습니다.