### PR TITLE
fix: 그룹 매칭 관심 분야 추가 요청 컬럼 명확화

### DIFF
--- a/src/main/kotlin/com/sight/domain/groupmatching/GroupMatchingFieldRequest.kt
+++ b/src/main/kotlin/com/sight/domain/groupmatching/GroupMatchingFieldRequest.kt
@@ -20,8 +20,8 @@ data class GroupMatchingFieldRequest(
     @Column(name = "field_name", nullable = false, length = 255)
     val fieldName: String,
 
-    @Column(name = "request_reason", length = 1000)
-    val requestReason: String? = null,
+    @Column(name = "request_reason", nullable = false, length = 1000)
+    val requestReason: String,
 
     @Column(name = "approved_at")
     val approvedAt: LocalDateTime? = null,


### PR DESCRIPTION
- 그룹 매칭 관심 분야 추가 요청 모델이 기존에는 승인과 거절이 명확히 분리되지 않았습니다.
- 둘을 명확히 분리하기 위해 컬럼을 분리합니다.