### PR TITLE
feat: 그룹 관련 사이드 기능 구현을 위한 도메인 작성

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/dto/ListSchedulesResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/ListSchedulesResponse.kt
@@ -1,7 +1,7 @@
 package com.sight.controllers.http.dto
 
 import com.sight.domain.schedule.Schedule
-import com.sight.domain.schedule.ScheduleCategory
+import com.sight.domain.schedule.ScheduleCategoryOld
 
 data class ListSchedulesResponse(
     val count: Int,
@@ -21,7 +21,7 @@ data class ScheduleDto(
     val id: String,
     val title: String,
     val startTime: String,
-    val category: ScheduleCategory?,
+    val category: ScheduleCategoryOld?,
 ) {
     companion object {
         fun from(schedule: Schedule): ScheduleDto {
@@ -29,7 +29,7 @@ data class ScheduleDto(
                 id = schedule.id.toString(),
                 title = schedule.title,
                 startTime = schedule.scheduledAt.toString(),
-                category = ScheduleCategory.fromCode(schedule.categoryCode),
+                category = ScheduleCategoryOld.fromCode(schedule.categoryCode),
             )
         }
     }

--- a/src/main/kotlin/com/sight/domain/file/FileUpload.kt
+++ b/src/main/kotlin/com/sight/domain/file/FileUpload.kt
@@ -9,14 +9,14 @@ import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "r2_file_upload")
-data class R2FileUpload(
+@Table(name = "file_upload")
+data class FileUpload(
     @Id
     @Column(name = "id", nullable = false, length = 100)
     val id: String,
 
-    @Column(name = "r2_key", nullable = false, length = 255)
-    val r2Key: String,
+    @Column(name = "file_key", nullable = false, length = 255)
+    val fileKey: String,
 
     @Column(name = "member_id", nullable = false)
     val memberId: Long,

--- a/src/main/kotlin/com/sight/domain/file/R2FileUpload.kt
+++ b/src/main/kotlin/com/sight/domain/file/R2FileUpload.kt
@@ -1,0 +1,34 @@
+package com.sight.domain.file
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.ColumnDefault
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "r2_file_upload")
+data class R2FileUpload(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "r2_key", nullable = false, length = 255)
+    val r2Key: String,
+
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long,
+
+    @Column(name = "api_path", nullable = false, length = 255)
+    val apiPath: String,
+
+    @Column(name = "is_verified", nullable = false, columnDefinition = "TINYINT")
+    @ColumnDefault("0")
+    val isVerified: Boolean = false,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/group/GroupActivityReport.kt
+++ b/src/main/kotlin/com/sight/domain/group/GroupActivityReport.kt
@@ -21,8 +21,8 @@ data class GroupActivityReport(
     @Column(name = "seminar_id", nullable = false, length = 100)
     val seminarId: String,
 
-    @Column(name = "report_file_r2_key", nullable = false, length = 255)
-    val reportFileR2Key: String,
+    @Column(name = "report_file_key", nullable = false, length = 255)
+    val reportFileKey: String,
 
     @Column(name = "is_presentation", nullable = false, columnDefinition = "TINYINT")
     val isPresentation: Boolean,

--- a/src/main/kotlin/com/sight/domain/group/GroupActivityReport.kt
+++ b/src/main/kotlin/com/sight/domain/group/GroupActivityReport.kt
@@ -1,0 +1,37 @@
+package com.sight.domain.group
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "group_activity_report")
+data class GroupActivityReport(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "group_id", nullable = false)
+    val groupId: Long,
+
+    @Column(name = "seminar_id", nullable = false, length = 100)
+    val seminarId: String,
+
+    @Column(name = "report_file_r2_key", nullable = false, length = 255)
+    val reportFileR2Key: String,
+
+    @Column(name = "is_presentation", nullable = false, columnDefinition = "TINYINT")
+    val isPresentation: Boolean,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/schedule/Schedule.kt
+++ b/src/main/kotlin/com/sight/domain/schedule/Schedule.kt
@@ -35,5 +35,5 @@ data class Schedule(
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime = LocalDateTime.now(),
 ) {
-    fun getCategory(): ScheduleCategory? = ScheduleCategory.fromCode(categoryCode)
+    fun getCategory(): ScheduleCategoryOld? = ScheduleCategoryOld.fromCode(categoryCode)
 }

--- a/src/main/kotlin/com/sight/domain/schedule/ScheduleCategory.kt
+++ b/src/main/kotlin/com/sight/domain/schedule/ScheduleCategory.kt
@@ -1,15 +1,12 @@
 package com.sight.domain.schedule
 
-enum class ScheduleCategory(val code: Long, val label: String) {
-    ROOM_405(32529, "405호"),
-    ROOM_406(32530, "406호"),
-    ROOM_410(32531, "410호"),
-    CLUB(7742, "동아리"),
-    ACADEMIC(7743, "학사"),
-    EXTERNAL(7744, "외부"),
-    ;
-
-    companion object {
-        fun fromCode(code: Long): ScheduleCategory? = entries.find { it.code == code }
-    }
+enum class ScheduleCategory(val label: String) {
+    CLUB("동아리"),
+    ACADEMIC("학사"),
+    EXTERNAL("외부"),
+    MANAGEMENT("운영"),
+    GROUP_ACTIVITY("그룹활동"),
+    SEMINAR("세미나"),
+    AFTERPARTY("뒷풀이"),
+    OTHER("기타"),
 }

--- a/src/main/kotlin/com/sight/domain/schedule/ScheduleCategoryOld.kt
+++ b/src/main/kotlin/com/sight/domain/schedule/ScheduleCategoryOld.kt
@@ -1,0 +1,15 @@
+package com.sight.domain.schedule
+
+enum class ScheduleCategoryOld(val code: Long, val label: String) {
+    ROOM_405(32529, "405호"),
+    ROOM_406(32530, "406호"),
+    ROOM_410(32531, "410호"),
+    CLUB(7742, "동아리"),
+    ACADEMIC(7743, "학사"),
+    EXTERNAL(7744, "외부"),
+    ;
+
+    companion object {
+        fun fromCode(code: Long): ScheduleCategoryOld? = entries.find { it.code == code }
+    }
+}

--- a/src/main/kotlin/com/sight/domain/schedule/ScheduleMemberApply.kt
+++ b/src/main/kotlin/com/sight/domain/schedule/ScheduleMemberApply.kt
@@ -1,0 +1,35 @@
+package com.sight.domain.schedule
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.io.Serializable
+import java.time.LocalDateTime
+
+data class ScheduleMemberApplyId(
+    val memberId: Long = 0,
+    val scheduleId: Long = 0,
+) : Serializable
+
+@Entity
+@Table(name = "khlug_schedule_member_apply")
+@IdClass(ScheduleMemberApplyId::class)
+data class ScheduleMemberApply(
+    @Id
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long,
+
+    @Id
+    @Column(name = "schedule_id", nullable = false)
+    val scheduleId: Long,
+
+    @Column(name = "attended_at")
+    val attendedAt: LocalDateTime? = null,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/seminar/BigSeminar.kt
+++ b/src/main/kotlin/com/sight/domain/seminar/BigSeminar.kt
@@ -1,0 +1,29 @@
+package com.sight.domain.seminar
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "big_seminar")
+data class BigSeminar(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "schedule_id", nullable = false)
+    val scheduleId: Long,
+
+    @Column(name = "is_summer_season", nullable = false, columnDefinition = "TINYINT")
+    val isSummerSeason: Boolean,
+
+    @Column(name = "is_speak_after", nullable = false, columnDefinition = "TINYINT")
+    val isSpeakAfter: Boolean,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)


### PR DESCRIPTION
그룹 활동 보고, 파일 업로드, 스케줄, 세미나 관련 API 구현에 필요한 도메인 엔티티를 추가합니다.

## 추가된 도메인
| 이름 | 용도 |
|-----|-----|
|FileUpload|R2를 통해 파일 업로드|
|GroupActivityReport|그룹 활동 보고
|ScheduleMemberApply| 스케줄 참가 신청 및 출석
|BigSeminar| 개강총회/종강총회
|ScheduleCategory| 스케줄 카테고리 enum
