### PR TITLE
feat: 그룹 포트폴리오 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/GroupController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupController.kt
@@ -7,6 +7,7 @@ import com.sight.controllers.http.dto.CreateGroupResponse
 import com.sight.controllers.http.dto.GroupLeaderResponse
 import com.sight.controllers.http.dto.GroupResponse
 import com.sight.controllers.http.dto.ListGroupsResponse
+import com.sight.controllers.http.dto.PublishPortfolioResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
@@ -17,6 +18,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -121,6 +123,26 @@ class GroupController(
                 answerId = request.groupMatchingParams!!.answerId,
             )
         }
+    }
+
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @PostMapping("/groups/{groupId}/portfolio")
+    fun publishPortfolio(
+        @PathVariable groupId: Long,
+        requester: Requester,
+    ): PublishPortfolioResponse {
+        val published = groupService.publishPortfolio(groupId, requester.userId)
+        return PublishPortfolioResponse(published = published)
+    }
+
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @DeleteMapping("/groups/{groupId}/portfolio")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun cancelPortfolio(
+        @PathVariable groupId: Long,
+        requester: Requester,
+    ) {
+        groupService.cancelPortfolio(groupId, requester.userId)
     }
 
     @Auth([UserRole.MANAGER])

--- a/src/main/kotlin/com/sight/controllers/http/dto/PublishPortfolioResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/PublishPortfolioResponse.kt
@@ -1,0 +1,5 @@
+package com.sight.controllers.http.dto
+
+data class PublishPortfolioResponse(
+    val published: Boolean,
+)

--- a/src/main/kotlin/com/sight/service/GroupService.kt
+++ b/src/main/kotlin/com/sight/service/GroupService.kt
@@ -1,9 +1,14 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.ForbiddenException
 import com.sight.core.exception.InternalServerErrorException
+import com.sight.core.exception.NotFoundException
 import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
 import com.sight.domain.group.GroupState
+import com.sight.domain.notification.NotificationCategory
+import com.sight.repository.GroupMemberRepository
 import com.sight.repository.GroupRepository
 import com.sight.repository.dto.GroupListDto
 import org.springframework.stereotype.Service
@@ -34,6 +39,9 @@ data class GroupListResult(
 @Service
 class GroupService(
     private val groupRepository: GroupRepository,
+    private val groupMemberRepository: GroupMemberRepository,
+    private val pointService: PointService,
+    private val notificationService: NotificationService,
 ) {
     @Transactional(readOnly = true)
     fun listGroups(
@@ -51,6 +59,54 @@ class GroupService(
             count = count,
             groups = groups.map { it.toGroupListItem() },
         )
+    }
+
+    @Transactional
+    fun publishPortfolio(
+        groupId: Long,
+        requesterId: Long,
+    ): Boolean {
+        val group = groupRepository.findById(groupId).orElseThrow { NotFoundException("그룹을 찾을 수 없습니다.") }
+        if (group.master != requesterId) throw ForbiddenException("그룹장만 포트폴리오를 발행할 수 있습니다.")
+        if (group.portfolio) throw BadRequestException("이미 발행된 포트폴리오입니다.")
+
+        groupRepository.save(group.copy(portfolio = true))
+
+        val members = groupMemberRepository.findByGroupId(groupId)
+        members.forEach { member ->
+            pointService.givePoint(member.member, 10, "포트폴리오 발행")
+            notificationService.createNotification(
+                userId = member.member,
+                category = NotificationCategory.GROUP,
+                title = "포트폴리오 발행",
+                content = "${group.title} 그룹의 포트폴리오가 발행되었습니다.",
+            )
+        }
+
+        return true
+    }
+
+    @Transactional
+    fun cancelPortfolio(
+        groupId: Long,
+        requesterId: Long,
+    ) {
+        val group = groupRepository.findById(groupId).orElseThrow { NotFoundException("그룹을 찾을 수 없습니다.") }
+        if (group.master != requesterId) throw ForbiddenException("그룹장만 포트폴리오를 취소할 수 있습니다.")
+        if (!group.portfolio) throw NotFoundException("발행된 포트폴리오가 없습니다.")
+
+        groupRepository.save(group.copy(portfolio = false))
+
+        val members = groupMemberRepository.findByGroupId(groupId)
+        members.forEach { member ->
+            pointService.givePoint(member.member, -10, "포트폴리오 취소")
+            notificationService.createNotification(
+                userId = member.member,
+                category = NotificationCategory.GROUP,
+                title = "포트폴리오 취소",
+                content = "${group.title} 그룹의 포트폴리오가 취소되었습니다.",
+            )
+        }
     }
 
     private fun GroupListDto.toGroupListItem(): GroupListItem =

--- a/src/test/kotlin/com/sight/service/GroupServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/GroupServiceTest.kt
@@ -1,6 +1,14 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.ForbiddenException
+import com.sight.core.exception.NotFoundException
+import com.sight.domain.group.Group
+import com.sight.domain.group.GroupCategory
+import com.sight.domain.group.GroupMember
 import com.sight.domain.group.GroupOrderBy
+import com.sight.domain.group.GroupState
+import com.sight.repository.GroupMemberRepository
 import com.sight.repository.GroupRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -9,14 +17,31 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import java.util.Optional
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class GroupServiceTest {
     private val groupRepository = mock<GroupRepository>()
+    private val groupMemberRepository = mock<GroupMemberRepository>()
+    private val pointService = mock<PointService>()
+    private val notificationService = mock<NotificationService>()
     private lateinit var groupService: GroupService
+
+    private val baseGroup =
+        Group(
+            id = 1L,
+            category = GroupCategory.STUDY,
+            title = "테스트 그룹",
+            author = 10L,
+            master = 10L,
+            state = GroupState.PROGRESS,
+            portfolio = false,
+        )
 
     @BeforeEach
     fun setUp() {
-        groupService = GroupService(groupRepository)
+        groupService = GroupService(groupRepository, groupMemberRepository, pointService, notificationService)
         given(groupRepository.findGroups(any(), any(), any(), any(), any(), any())).willReturn(emptyList())
         given(groupRepository.countGroups(any(), any(), any())).willReturn(0L)
     }
@@ -73,5 +98,105 @@ class GroupServiceTest {
         // then
         verify(groupRepository).findGroups(eq(0), eq(10), eq(true), eq(true), eq(GroupOrderBy.CHANGED_AT), eq(123L))
         verify(groupRepository).countGroups(eq(true), eq(true), eq(123L))
+    }
+
+    @Test
+    fun `publishPortfolio는 그룹장이 미발행 그룹에 요청하면 portfolio를 true로 변경하고 멤버에게 포인트와 알림을 전송한다`() {
+        // given
+        val members = listOf(GroupMember(group = 1L, member = 20L), GroupMember(group = 1L, member = 30L))
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
+        given(groupMemberRepository.findByGroupId(1L)).willReturn(members)
+
+        // when
+        val result = groupService.publishPortfolio(groupId = 1L, requesterId = 10L)
+
+        // then
+        assertTrue(result)
+        verify(groupRepository).save(baseGroup.copy(portfolio = true))
+        verify(pointService).givePoint(20L, 10, "포트폴리오 발행")
+        verify(pointService).givePoint(30L, 10, "포트폴리오 발행")
+    }
+
+    @Test
+    fun `publishPortfolio는 이미 발행된 그룹에 요청하면 400을 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup.copy(portfolio = true)))
+
+        // when & then
+        assertFailsWith<BadRequestException> {
+            groupService.publishPortfolio(groupId = 1L, requesterId = 10L)
+        }
+    }
+
+    @Test
+    fun `publishPortfolio는 그룹장이 아닌 멤버가 요청하면 403을 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
+
+        // when & then
+        assertFailsWith<ForbiddenException> {
+            groupService.publishPortfolio(groupId = 1L, requesterId = 99L)
+        }
+    }
+
+    @Test
+    fun `publishPortfolio는 존재하지 않는 그룹에 요청하면 404를 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.empty())
+
+        // when & then
+        assertFailsWith<NotFoundException> {
+            groupService.publishPortfolio(groupId = 1L, requesterId = 10L)
+        }
+    }
+
+    @Test
+    fun `cancelPortfolio는 그룹장이 발행 중인 그룹에 요청하면 portfolio를 false로 변경하고 멤버에게 포인트와 알림을 전송한다`() {
+        // given
+        val publishedGroup = baseGroup.copy(portfolio = true)
+        val members = listOf(GroupMember(group = 1L, member = 20L), GroupMember(group = 1L, member = 30L))
+        given(groupRepository.findById(1L)).willReturn(Optional.of(publishedGroup))
+        given(groupMemberRepository.findByGroupId(1L)).willReturn(members)
+
+        // when
+        groupService.cancelPortfolio(groupId = 1L, requesterId = 10L)
+
+        // then
+        verify(groupRepository).save(publishedGroup.copy(portfolio = false))
+        verify(pointService).givePoint(20L, -10, "포트폴리오 취소")
+        verify(pointService).givePoint(30L, -10, "포트폴리오 취소")
+    }
+
+    @Test
+    fun `cancelPortfolio는 발행되지 않은 그룹에 요청하면 404를 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
+
+        // when & then
+        assertFailsWith<NotFoundException> {
+            groupService.cancelPortfolio(groupId = 1L, requesterId = 10L)
+        }
+    }
+
+    @Test
+    fun `cancelPortfolio는 그룹장이 아닌 멤버가 요청하면 403을 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup.copy(portfolio = true)))
+
+        // when & then
+        assertFailsWith<ForbiddenException> {
+            groupService.cancelPortfolio(groupId = 1L, requesterId = 99L)
+        }
+    }
+
+    @Test
+    fun `cancelPortfolio는 존재하지 않는 그룹에 요청하면 404를 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.empty())
+
+        // when & then
+        assertFailsWith<NotFoundException> {
+            groupService.cancelPortfolio(groupId = 1L, requesterId = 10L)
+        }
     }
 }

--- a/src/test/kotlin/com/sight/service/GroupServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/GroupServiceTest.kt
@@ -101,7 +101,7 @@ class GroupServiceTest {
     }
 
     @Test
-    fun `publishPortfolio는 그룹장이 미발행 그룹에 요청하면 portfolio를 true로 변경하고 멤버에게 포인트와 알림을 전송한다`() {
+    fun `publishPortfolio는 그룹장이 미발행 그룹에 요청하면 포트폴리오 발행 여부를 true로 변경하고 멤버에게 포인트와 알림을 전송한다`() {
         // given
         val members = listOf(GroupMember(group = 1L, member = 20L), GroupMember(group = 1L, member = 30L))
         given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
@@ -151,7 +151,7 @@ class GroupServiceTest {
     }
 
     @Test
-    fun `cancelPortfolio는 그룹장이 발행 중인 그룹에 요청하면 portfolio를 false로 변경하고 멤버에게 포인트와 알림을 전송한다`() {
+    fun `cancelPortfolio는 그룹장이 발행 중인 그룹에 요청하면 포트폴리오 발행 여부를 false로 변경하고 멤버에게 포인트와 알림을 전송한다`() {
         // given
         val publishedGroup = baseGroup.copy(portfolio = true)
         val members = listOf(GroupMember(group = 1L, member = 20L), GroupMember(group = 1L, member = 30L))


### PR DESCRIPTION
그룹 포트폴리오 발행 및 취소 기능을 구현했습니다.  


## 포트폴리오 발행 API
POST /groups/:groupId/portfolio

#### 테스트 케이스

1. 그룹장이 미발행 그룹에 요청 → `group.portfolio = true`로 변경, 멤버 전체 +10, 200 반환
2. 이미 발행 중인 그룹에 요청 → 400 반환
3. 그룹원(비그룹장)이 요청 → 403 반환
4. 존재하지 않는 그룹 ID 요청 → 404 반환
5. 발행 성공 시 → 그룹 멤버 전체에게 알림 발송
   <br/>
  
## 포트폴리오 삭제 API
DELETE /groups/:groupId/bookmark

#### 테스트 케이스

1. 즐겨찾기 된 그룹에 요청 → `group_bookmark` row DELETE, 204 반환
2. 즐겨찾기 안 된 그룹에 요청 → 404 반환
3. 존재하지 않는 그룹 ID 요청 → 404 반환
4. 미인증 요청 → 401 반환