### PR TITLE
feat: 그룹 즐겨찾기 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/GroupController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupController.kt
@@ -17,6 +17,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -121,6 +122,26 @@ class GroupController(
                 answerId = request.groupMatchingParams!!.answerId,
             )
         }
+    }
+
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @PostMapping("/groups/{groupId}/bookmark")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun addBookmark(
+        @PathVariable groupId: Long,
+        requester: Requester,
+    ) {
+        groupService.addBookmark(groupId, requester.userId)
+    }
+
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @DeleteMapping("/groups/{groupId}/bookmark")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun cancelBookmark(
+        @PathVariable groupId: Long,
+        requester: Requester,
+    ) {
+        groupService.cancelBookmark(groupId, requester.userId)
     }
 
     @Auth([UserRole.MANAGER])

--- a/src/main/kotlin/com/sight/repository/GroupBookmarkRepository.kt
+++ b/src/main/kotlin/com/sight/repository/GroupBookmarkRepository.kt
@@ -1,0 +1,17 @@
+package com.sight.repository
+
+import com.sight.domain.group.GroupBookmark
+import com.sight.domain.group.GroupBookmarkId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GroupBookmarkRepository : JpaRepository<GroupBookmark, GroupBookmarkId> {
+    fun existsByMemberAndGroup(
+        member: Long,
+        group: Long,
+    ): Boolean
+
+    fun deleteByMemberAndGroup(
+        member: Long,
+        group: Long,
+    )
+}

--- a/src/main/kotlin/com/sight/service/GroupService.kt
+++ b/src/main/kotlin/com/sight/service/GroupService.kt
@@ -1,8 +1,8 @@
 package com.sight.service
 
-import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.InternalServerErrorException
 import com.sight.core.exception.NotFoundException
+import com.sight.core.exception.UnprocessableEntityException
 import com.sight.domain.group.GroupBookmark
 import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
@@ -65,7 +65,7 @@ class GroupService(
     ) {
         groupRepository.findById(groupId).orElseThrow { NotFoundException("그룹을 찾을 수 없습니다.") }
         if (groupBookmarkRepository.existsByMemberAndGroup(requesterId, groupId)) {
-            throw BadRequestException("이미 즐겨찾기한 그룹입니다.")
+            throw UnprocessableEntityException("이미 즐겨찾기한 그룹입니다.")
         }
         groupBookmarkRepository.save(GroupBookmark(member = requesterId, group = groupId))
     }
@@ -77,7 +77,7 @@ class GroupService(
     ) {
         groupRepository.findById(groupId).orElseThrow { NotFoundException("그룹을 찾을 수 없습니다.") }
         if (!groupBookmarkRepository.existsByMemberAndGroup(requesterId, groupId)) {
-            throw NotFoundException("이미 즐겨찾기 되어있지 않습니다.")
+            throw UnprocessableEntityException("즐겨찾기 되어있지 않습니다.")
         }
         groupBookmarkRepository.deleteByMemberAndGroup(requesterId, groupId)
     }

--- a/src/main/kotlin/com/sight/service/GroupService.kt
+++ b/src/main/kotlin/com/sight/service/GroupService.kt
@@ -1,9 +1,13 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.InternalServerErrorException
+import com.sight.core.exception.NotFoundException
+import com.sight.domain.group.GroupBookmark
 import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
 import com.sight.domain.group.GroupState
+import com.sight.repository.GroupBookmarkRepository
 import com.sight.repository.GroupRepository
 import com.sight.repository.dto.GroupListDto
 import org.springframework.stereotype.Service
@@ -34,6 +38,7 @@ data class GroupListResult(
 @Service
 class GroupService(
     private val groupRepository: GroupRepository,
+    private val groupBookmarkRepository: GroupBookmarkRepository,
 ) {
     @Transactional(readOnly = true)
     fun listGroups(
@@ -51,6 +56,30 @@ class GroupService(
             count = count,
             groups = groups.map { it.toGroupListItem() },
         )
+    }
+
+    @Transactional
+    fun addBookmark(
+        groupId: Long,
+        requesterId: Long,
+    ) {
+        groupRepository.findById(groupId).orElseThrow { NotFoundException("그룹을 찾을 수 없습니다.") }
+        if (groupBookmarkRepository.existsByMemberAndGroup(requesterId, groupId)) {
+            throw BadRequestException("이미 즐겨찾기한 그룹입니다.")
+        }
+        groupBookmarkRepository.save(GroupBookmark(member = requesterId, group = groupId))
+    }
+
+    @Transactional
+    fun cancelBookmark(
+        groupId: Long,
+        requesterId: Long,
+    ) {
+        groupRepository.findById(groupId).orElseThrow { NotFoundException("그룹을 찾을 수 없습니다.") }
+        if (!groupBookmarkRepository.existsByMemberAndGroup(requesterId, groupId)) {
+            throw NotFoundException("이미 즐겨찾기 되어있지 않습니다.")
+        }
+        groupBookmarkRepository.deleteByMemberAndGroup(requesterId, groupId)
     }
 
     private fun GroupListDto.toGroupListItem(): GroupListItem =

--- a/src/test/kotlin/com/sight/service/GroupServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/GroupServiceTest.kt
@@ -1,22 +1,43 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.NotFoundException
+import com.sight.domain.group.Group
+import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
+import com.sight.domain.group.GroupState
+import com.sight.repository.GroupBookmarkRepository
 import com.sight.repository.GroupRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import java.util.Optional
+import kotlin.test.assertFailsWith
 
 class GroupServiceTest {
     private val groupRepository = mock<GroupRepository>()
+    private val groupBookmarkRepository = mock<GroupBookmarkRepository>()
     private lateinit var groupService: GroupService
+
+    private val baseGroup =
+        Group(
+            id = 1L,
+            category = GroupCategory.STUDY,
+            title = "테스트 그룹",
+            author = 10L,
+            master = 10L,
+            state = GroupState.PROGRESS,
+        )
 
     @BeforeEach
     fun setUp() {
-        groupService = GroupService(groupRepository)
+        groupService = GroupService(groupRepository, groupBookmarkRepository)
         given(groupRepository.findGroups(any(), any(), any(), any(), any(), any())).willReturn(emptyList())
         given(groupRepository.countGroups(any(), any(), any())).willReturn(0L)
     }
@@ -73,5 +94,79 @@ class GroupServiceTest {
         // then
         verify(groupRepository).findGroups(eq(0), eq(10), eq(true), eq(true), eq(GroupOrderBy.CHANGED_AT), eq(123L))
         verify(groupRepository).countGroups(eq(true), eq(true), eq(123L))
+    }
+
+    @Test
+    fun `addBookmark는 그룹이 존재하고 즐겨찾기하지 않은 경우 즐겨찾기를 추가한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
+        given(groupBookmarkRepository.existsByMemberAndGroup(10L, 1L)).willReturn(false)
+
+        // when
+        groupService.addBookmark(groupId = 1L, requesterId = 10L)
+
+        // then
+        verify(groupBookmarkRepository).save(argThat { member == 10L && group == 1L })
+    }
+
+    @Test
+    fun `addBookmark는 이미 즐겨찾기한 그룹에 요청하면 400을 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
+        given(groupBookmarkRepository.existsByMemberAndGroup(10L, 1L)).willReturn(true)
+
+        // when & then
+        assertFailsWith<BadRequestException> {
+            groupService.addBookmark(groupId = 1L, requesterId = 10L)
+        }
+        verify(groupBookmarkRepository, never()).save(any())
+    }
+
+    @Test
+    fun `addBookmark는 존재하지 않는 그룹에 요청하면 404를 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.empty())
+
+        // when & then
+        assertFailsWith<NotFoundException> {
+            groupService.addBookmark(groupId = 1L, requesterId = 10L)
+        }
+    }
+
+    @Test
+    fun `cancelBookmark는 즐겨찾기된 그룹에 요청하면 즐겨찾기를 취소한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
+        given(groupBookmarkRepository.existsByMemberAndGroup(10L, 1L)).willReturn(true)
+
+        // when
+        groupService.cancelBookmark(groupId = 1L, requesterId = 10L)
+
+        // then
+        verify(groupBookmarkRepository).deleteByMemberAndGroup(10L, 1L)
+    }
+
+    @Test
+    fun `cancelBookmark는 즐겨찾기하지 않은 그룹에 요청하면 404를 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
+        given(groupBookmarkRepository.existsByMemberAndGroup(10L, 1L)).willReturn(false)
+
+        // when & then
+        assertFailsWith<NotFoundException> {
+            groupService.cancelBookmark(groupId = 1L, requesterId = 10L)
+        }
+        verify(groupBookmarkRepository, never()).deleteByMemberAndGroup(any(), any())
+    }
+
+    @Test
+    fun `cancelBookmark는 존재하지 않는 그룹에 요청하면 404를 반환한다`() {
+        // given
+        given(groupRepository.findById(1L)).willReturn(Optional.empty())
+
+        // when & then
+        assertFailsWith<NotFoundException> {
+            groupService.cancelBookmark(groupId = 1L, requesterId = 10L)
+        }
     }
 }

--- a/src/test/kotlin/com/sight/service/GroupServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/GroupServiceTest.kt
@@ -1,7 +1,7 @@
 package com.sight.service
 
-import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.NotFoundException
+import com.sight.core.exception.UnprocessableEntityException
 import com.sight.domain.group.Group
 import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
@@ -110,13 +110,13 @@ class GroupServiceTest {
     }
 
     @Test
-    fun `addBookmark는 이미 즐겨찾기한 그룹에 요청하면 400을 반환한다`() {
+    fun `addBookmark는 이미 즐겨찾기한 그룹에 요청하면 422를 반환한다`() {
         // given
         given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
         given(groupBookmarkRepository.existsByMemberAndGroup(10L, 1L)).willReturn(true)
 
         // when & then
-        assertFailsWith<BadRequestException> {
+        assertFailsWith<UnprocessableEntityException> {
             groupService.addBookmark(groupId = 1L, requesterId = 10L)
         }
         verify(groupBookmarkRepository, never()).save(any())
@@ -147,13 +147,13 @@ class GroupServiceTest {
     }
 
     @Test
-    fun `cancelBookmark는 즐겨찾기하지 않은 그룹에 요청하면 404를 반환한다`() {
+    fun `cancelBookmark는 즐겨찾기하지 않은 그룹에 요청하면 422를 반환한다`() {
         // given
         given(groupRepository.findById(1L)).willReturn(Optional.of(baseGroup))
         given(groupBookmarkRepository.existsByMemberAndGroup(10L, 1L)).willReturn(false)
 
         // when & then
-        assertFailsWith<NotFoundException> {
+        assertFailsWith<UnprocessableEntityException> {
             groupService.cancelBookmark(groupId = 1L, requesterId = 10L)
         }
         verify(groupBookmarkRepository, never()).deleteByMemberAndGroup(any(), any())


### PR DESCRIPTION
그룹 즐겨찾기를 추가/삭제 하는 기능을 구현했습니다.  


## 북마크 추가 API
POST /groups/:groupId/bookmark


#### 테스트 케이스

1. 즐겨찾기 안 된 그룹에 요청 → `group_bookmark` row INSERT, 201 반환
2. 이미 즐겨찾기 된 그룹에 요청 → 400 반환
3. 존재하지 않는 그룹 ID 요청 → 404 반환
4. 미인증 요청 → 401 반환
5. 추가 성공 시 → 본인에게 알림 발송

<br/>

## 북마크 삭제 API
DELETE /groups/:groupId/bookmark


#### 테스트 케이스

1. 즐겨찾기 된 그룹에 요청 → `group_bookmark` row DELETE, 204 반환
2. 즐겨찾기 안 된 그룹에 요청 → 404 반환
3. 존재하지 않는 그룹 ID 요청 → 404 반환
4. 미인증 요청 → 401 반환