### PR TITLE
feat: 그룹 목록 조회 API 다중 필터링 및 검색 기능 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/GroupController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupController.kt
@@ -38,6 +38,10 @@ class GroupController(
         @RequestParam(defaultValue = "10") @Min(1) @Max(100) limit: Int,
         @RequestParam(required = false) bookmarked: Boolean?,
         @RequestParam(required = false) joined: Boolean?,
+        @RequestParam(required = false) category: List<String>?,
+        @RequestParam(required = false) state: String?,
+        @RequestParam(required = false) interest: String?,
+        @RequestParam(required = false) keyword: String?,
         @RequestParam(required = false) orderBy: GroupOrderBy?,
         requester: Requester,
     ): ListGroupsResponse {
@@ -47,6 +51,10 @@ class GroupController(
                 limit = limit,
                 bookmarked = bookmarked,
                 joined = joined,
+                categories = category,
+                state = state,
+                interest = interest,
+                keyword = keyword,
                 orderBy = orderBy,
                 requesterId = requester.userId,
             )

--- a/src/main/kotlin/com/sight/domain/group/GroupCategory.kt
+++ b/src/main/kotlin/com/sight/domain/group/GroupCategory.kt
@@ -7,4 +7,9 @@ enum class GroupCategory(val value: String) {
     DOCUMENTATION("documentation"),
     PROGRAM("program"),
     EDUCATION("education"),
+    ;
+
+    companion object {
+        fun fromValue(value: String): GroupCategory? = entries.find { it.value == value }
+    }
 }

--- a/src/main/kotlin/com/sight/domain/group/GroupState.kt
+++ b/src/main/kotlin/com/sight/domain/group/GroupState.kt
@@ -6,4 +6,9 @@ enum class GroupState(val value: String) {
     SUSPEND("suspend"), // 중단
     END_SUCCESS("end-success"), // 종료 (성공)
     END_FAIL("end-fail"), // 종료 (실패)
+    ;
+
+    companion object {
+        fun fromValue(value: String): GroupState? = entries.find { it.value == value }
+    }
 }

--- a/src/main/kotlin/com/sight/repository/GroupRepositoryCustom.kt
+++ b/src/main/kotlin/com/sight/repository/GroupRepositoryCustom.kt
@@ -1,6 +1,8 @@
 package com.sight.repository
 
+import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
+import com.sight.domain.group.GroupState
 import com.sight.repository.dto.GroupListDto
 
 interface GroupRepositoryCustom {
@@ -9,6 +11,10 @@ interface GroupRepositoryCustom {
         limit: Int,
         joined: Boolean? = null,
         bookmarked: Boolean? = null,
+        categories: List<GroupCategory>? = null,
+        state: GroupState? = null,
+        interest: String? = null,
+        keyword: String? = null,
         orderBy: GroupOrderBy? = null,
         requesterId: Long,
     ): List<GroupListDto>
@@ -16,6 +22,10 @@ interface GroupRepositoryCustom {
     fun countGroups(
         joined: Boolean? = null,
         bookmarked: Boolean? = null,
+        categories: List<GroupCategory>? = null,
+        state: GroupState? = null,
+        interest: String? = null,
+        keyword: String? = null,
         requesterId: Long,
     ): Long
 }

--- a/src/main/kotlin/com/sight/repository/GroupRepositoryImpl.kt
+++ b/src/main/kotlin/com/sight/repository/GroupRepositoryImpl.kt
@@ -157,4 +157,3 @@ class GroupRepositoryImpl(
             member.realname,
         )
 }
-

--- a/src/main/kotlin/com/sight/repository/GroupRepositoryImpl.kt
+++ b/src/main/kotlin/com/sight/repository/GroupRepositoryImpl.kt
@@ -5,7 +5,9 @@ import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
+import com.sight.domain.group.GroupState
 import com.sight.domain.group.QGroup
 import com.sight.domain.group.QGroupBookmark
 import com.sight.domain.group.QGroupMember
@@ -27,6 +29,10 @@ class GroupRepositoryImpl(
         limit: Int,
         joined: Boolean?,
         bookmarked: Boolean?,
+        categories: List<GroupCategory>?,
+        state: GroupState?,
+        interest: String?,
+        keyword: String?,
         orderBy: GroupOrderBy?,
         requesterId: Long,
     ): List<GroupListDto> {
@@ -37,7 +43,7 @@ class GroupRepositoryImpl(
                 .join(member).on(group.master.eq(member.id))
 
         applyJoins(query, joined, bookmarked)
-        applyWhere(query, joined, bookmarked, requesterId)
+        applyWhere(query, joined, bookmarked, categories, state, interest, keyword, requesterId)
 
         return query
             .orderBy(resolveOrderBy(orderBy))
@@ -49,6 +55,10 @@ class GroupRepositoryImpl(
     override fun countGroups(
         joined: Boolean?,
         bookmarked: Boolean?,
+        categories: List<GroupCategory>?,
+        state: GroupState?,
+        interest: String?,
+        keyword: String?,
         requesterId: Long,
     ): Long {
         val query =
@@ -57,7 +67,7 @@ class GroupRepositoryImpl(
                 .from(group)
 
         applyJoins(query, joined, bookmarked)
-        applyWhere(query, joined, bookmarked, requesterId)
+        applyWhere(query, joined, bookmarked, categories, state, interest, keyword, requesterId)
 
         return query.fetchOne() ?: 0L
     }
@@ -79,6 +89,10 @@ class GroupRepositoryImpl(
         query: JPAQuery<*>,
         joined: Boolean?,
         bookmarked: Boolean?,
+        categories: List<GroupCategory>?,
+        state: GroupState?,
+        interest: String?,
+        keyword: String?,
         requesterId: Long,
     ) {
         val conditions = mutableListOf<BooleanExpression>()
@@ -88,6 +102,34 @@ class GroupRepositoryImpl(
         }
         if (bookmarked == true) {
             conditions.add(groupBookmark.member.eq(requesterId))
+        }
+
+        // category IN 조건
+        if (!categories.isNullOrEmpty()) {
+            conditions.add(group.category.`in`(categories))
+        }
+
+        // state 일치 조건
+        if (state != null) {
+            conditions.add(group.state.eq(state))
+        }
+
+        // interest: pipe(|) 구분자 기준 정확 매칭
+        // DB 값 예시: "웹|AI|보안" → interest=웹 으로 검색 시 매칭되어야 함
+        if (!interest.isNullOrBlank()) {
+            val exactMatch = group.interest.eq(interest)
+            val startsWith = group.interest.like("$interest|%")
+            val contains = group.interest.like("%|$interest|%")
+            val endsWith = group.interest.like("%|$interest")
+            conditions.add(exactMatch.or(startsWith).or(contains).or(endsWith))
+        }
+
+        // keyword: title, purpose, technology 중 하나라도 포함되면 매칭 (OR)
+        if (!keyword.isNullOrBlank()) {
+            val titleLike = group.title.containsIgnoreCase(keyword)
+            val purposeLike = group.purpose.containsIgnoreCase(keyword)
+            val technologyLike = group.technology.containsIgnoreCase(keyword)
+            conditions.add(titleLike.or(purposeLike).or(technologyLike))
         }
 
         if (conditions.isNotEmpty()) {
@@ -115,3 +157,4 @@ class GroupRepositoryImpl(
             member.realname,
         )
 }
+

--- a/src/main/kotlin/com/sight/service/GroupService.kt
+++ b/src/main/kotlin/com/sight/service/GroupService.kt
@@ -1,5 +1,6 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.InternalServerErrorException
 import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
@@ -41,11 +42,48 @@ class GroupService(
         limit: Int,
         bookmarked: Boolean?,
         joined: Boolean?,
+        categories: List<String>?,
+        state: String?,
+        interest: String?,
+        keyword: String?,
         orderBy: GroupOrderBy?,
         requesterId: Long,
     ): GroupListResult {
-        val groups = groupRepository.findGroups(offset, limit, joined, bookmarked, orderBy, requesterId)
-        val count = groupRepository.countGroups(joined, bookmarked, requesterId)
+        val validCategories =
+            categories?.map { value ->
+                GroupCategory.fromValue(value)
+                    ?: throw BadRequestException("유효하지 않은 카테고리입니다: $value")
+            }
+
+        val validState =
+            state?.let { value ->
+                GroupState.fromValue(value)
+                    ?: throw BadRequestException("유효하지 않은 상태입니다: $value")
+            }
+
+        val groups =
+            groupRepository.findGroups(
+                offset = offset,
+                limit = limit,
+                joined = joined,
+                bookmarked = bookmarked,
+                categories = validCategories,
+                state = validState,
+                interest = interest,
+                keyword = keyword,
+                orderBy = orderBy,
+                requesterId = requesterId,
+            )
+        val count =
+            groupRepository.countGroups(
+                joined = joined,
+                bookmarked = bookmarked,
+                categories = validCategories,
+                state = validState,
+                interest = interest,
+                keyword = keyword,
+                requesterId = requesterId,
+            )
 
         return GroupListResult(
             count = count,
@@ -57,11 +95,11 @@ class GroupService(
         GroupListItem(
             id = this.id,
             category =
-                GroupCategory.entries.firstOrNull { it.value == this.category }
+                GroupCategory.fromValue(this.category)
                     ?: throw InternalServerErrorException("알 수 없는 그룹 카테고리입니다: ${this.category}"),
             title = this.title,
             state =
-                GroupState.entries.firstOrNull { it.value == this.state }
+                GroupState.fromValue(this.state)
                     ?: throw InternalServerErrorException("알 수 없는 그룹 상태입니다: ${this.state}"),
             countMember = this.countMember,
             allowJoin = this.allowJoin,
@@ -73,3 +111,4 @@ class GroupService(
                 ),
         )
 }
+

--- a/src/main/kotlin/com/sight/service/GroupService.kt
+++ b/src/main/kotlin/com/sight/service/GroupService.kt
@@ -111,4 +111,3 @@ class GroupService(
                 ),
         )
 }
-

--- a/src/test/kotlin/com/sight/service/GroupServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/GroupServiceTest.kt
@@ -26,12 +26,27 @@ class GroupServiceTest {
         groupService = GroupService(groupRepository)
         given(
             groupRepository.findGroups(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
             ),
         ).willReturn(emptyList())
         given(
             groupRepository.countGroups(
-                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
             ),
         ).willReturn(0L)
     }
@@ -54,13 +69,24 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(20), eq(50), eq(null), eq(null),
-            isNull(), isNull(), isNull(), isNull(),
-            eq(null), eq(1L),
+            eq(20),
+            eq(50),
+            eq(null),
+            eq(null),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(null),
+            eq(1L),
         )
         verify(groupRepository).countGroups(
-            eq(null), eq(null),
-            isNull(), isNull(), isNull(), isNull(),
+            eq(null),
+            eq(null),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
             eq(1L),
         )
     }
@@ -83,13 +109,24 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(null), eq(true),
-            isNull(), isNull(), isNull(), isNull(),
-            eq(null), eq(123L),
+            eq(0),
+            eq(10),
+            eq(null),
+            eq(true),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(null),
+            eq(123L),
         )
         verify(groupRepository).countGroups(
-            eq(null), eq(true),
-            isNull(), isNull(), isNull(), isNull(),
+            eq(null),
+            eq(true),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
             eq(123L),
         )
     }
@@ -112,13 +149,24 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(6), eq(true), eq(null),
-            isNull(), isNull(), isNull(), isNull(),
-            eq(GroupOrderBy.CHANGED_AT), eq(123L),
+            eq(0),
+            eq(6),
+            eq(true),
+            eq(null),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(GroupOrderBy.CHANGED_AT),
+            eq(123L),
         )
         verify(groupRepository).countGroups(
-            eq(true), eq(null),
-            isNull(), isNull(), isNull(), isNull(),
+            eq(true),
+            eq(null),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
             eq(123L),
         )
     }
@@ -141,13 +189,24 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(true), eq(true),
-            isNull(), isNull(), isNull(), isNull(),
-            eq(GroupOrderBy.CHANGED_AT), eq(123L),
+            eq(0),
+            eq(10),
+            eq(true),
+            eq(true),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(GroupOrderBy.CHANGED_AT),
+            eq(123L),
         )
         verify(groupRepository).countGroups(
-            eq(true), eq(true),
-            isNull(), isNull(), isNull(), isNull(),
+            eq(true),
+            eq(true),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
             eq(123L),
         )
     }
@@ -172,9 +231,16 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(null), eq(null),
-            eq(listOf(GroupCategory.STUDY)), isNull(), isNull(), isNull(),
-            eq(null), eq(1L),
+            eq(0),
+            eq(10),
+            eq(null),
+            eq(null),
+            eq(listOf(GroupCategory.STUDY)),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(null),
+            eq(1L),
         )
     }
 
@@ -196,9 +262,16 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(null), eq(null),
-            eq(listOf(GroupCategory.STUDY, GroupCategory.PROJECT)), isNull(), isNull(), isNull(),
-            eq(null), eq(1L),
+            eq(0),
+            eq(10),
+            eq(null),
+            eq(null),
+            eq(listOf(GroupCategory.STUDY, GroupCategory.PROJECT)),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(null),
+            eq(1L),
         )
     }
 
@@ -244,9 +317,16 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(null), eq(null),
-            isNull(), eq(GroupState.PROGRESS), isNull(), isNull(),
-            eq(null), eq(1L),
+            eq(0),
+            eq(10),
+            eq(null),
+            eq(null),
+            isNull(),
+            eq(GroupState.PROGRESS),
+            isNull(),
+            isNull(),
+            eq(null),
+            eq(1L),
         )
     }
 
@@ -268,9 +348,16 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(null), eq(null),
-            isNull(), eq(GroupState.END_SUCCESS), isNull(), isNull(),
-            eq(null), eq(1L),
+            eq(0),
+            eq(10),
+            eq(null),
+            eq(null),
+            isNull(),
+            eq(GroupState.END_SUCCESS),
+            isNull(),
+            isNull(),
+            eq(null),
+            eq(1L),
         )
     }
 
@@ -316,9 +403,16 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(null), eq(null),
-            isNull(), isNull(), eq("웹"), isNull(),
-            eq(null), eq(1L),
+            eq(0),
+            eq(10),
+            eq(null),
+            eq(null),
+            isNull(),
+            isNull(),
+            eq("웹"),
+            isNull(),
+            eq(null),
+            eq(1L),
         )
     }
 
@@ -340,9 +434,16 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(null), eq(null),
-            isNull(), isNull(), isNull(), eq("Spring"),
-            eq(null), eq(1L),
+            eq(0),
+            eq(10),
+            eq(null),
+            eq(null),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq("Spring"),
+            eq(null),
+            eq(1L),
         )
     }
 
@@ -366,15 +467,20 @@ class GroupServiceTest {
 
         // then
         verify(groupRepository).findGroups(
-            eq(0), eq(10), eq(null), eq(null),
+            eq(0),
+            eq(10),
+            eq(null),
+            eq(null),
             eq(listOf(GroupCategory.STUDY, GroupCategory.PROJECT)),
             eq(GroupState.PROGRESS),
             eq("웹"),
             eq("Spring"),
-            eq(GroupOrderBy.CHANGED_AT), eq(1L),
+            eq(GroupOrderBy.CHANGED_AT),
+            eq(1L),
         )
         verify(groupRepository).countGroups(
-            eq(null), eq(null),
+            eq(null),
+            eq(null),
             eq(listOf(GroupCategory.STUDY, GroupCategory.PROJECT)),
             eq(GroupState.PROGRESS),
             eq("웹"),
@@ -388,7 +494,13 @@ class GroupServiceTest {
         // given
         given(
             groupRepository.countGroups(
-                eq(null), eq(null), eq(listOf(GroupCategory.STUDY)), eq(GroupState.PROGRESS), eq(null), eq(null), eq(1L)
+                eq(null),
+                eq(null),
+                eq(listOf(GroupCategory.STUDY)),
+                eq(GroupState.PROGRESS),
+                eq(null),
+                eq(null),
+                eq(1L),
             ),
         ).willReturn(42L)
 

--- a/src/test/kotlin/com/sight/service/GroupServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/GroupServiceTest.kt
@@ -1,14 +1,21 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
+import com.sight.domain.group.GroupCategory
 import com.sight.domain.group.GroupOrderBy
+import com.sight.domain.group.GroupState
 import com.sight.repository.GroupRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class GroupServiceTest {
     private val groupRepository = mock<GroupRepository>()
@@ -17,28 +24,74 @@ class GroupServiceTest {
     @BeforeEach
     fun setUp() {
         groupService = GroupService(groupRepository)
-        given(groupRepository.findGroups(any(), any(), any(), any(), any(), any())).willReturn(emptyList())
-        given(groupRepository.countGroups(any(), any(), any())).willReturn(0L)
+        given(
+            groupRepository.findGroups(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            ),
+        ).willReturn(emptyList())
+        given(
+            groupRepository.countGroups(
+                any(), any(), any(), any(), any(), any(), any(),
+            ),
+        ).willReturn(0L)
     }
 
     @Test
     fun `listGroups는 파라미터를 올바르게 전달한다`() {
         // when
-        groupService.listGroups(offset = 20, limit = 50, bookmarked = null, joined = null, orderBy = null, requesterId = 1L)
+        groupService.listGroups(
+            offset = 20,
+            limit = 50,
+            bookmarked = null,
+            joined = null,
+            categories = null,
+            state = null,
+            interest = null,
+            keyword = null,
+            orderBy = null,
+            requesterId = 1L,
+        )
 
         // then
-        verify(groupRepository).findGroups(eq(20), eq(50), eq(null), eq(null), eq(null), eq(1L))
-        verify(groupRepository).countGroups(eq(null), eq(null), eq(1L))
+        verify(groupRepository).findGroups(
+            eq(20), eq(50), eq(null), eq(null),
+            isNull(), isNull(), isNull(), isNull(),
+            eq(null), eq(1L),
+        )
+        verify(groupRepository).countGroups(
+            eq(null), eq(null),
+            isNull(), isNull(), isNull(), isNull(),
+            eq(1L),
+        )
     }
 
     @Test
     fun `listGroups는 bookmarked가 true이면 bookmarked 파라미터를 전달한다`() {
         // when
-        groupService.listGroups(offset = 0, limit = 10, bookmarked = true, joined = null, orderBy = null, requesterId = 123L)
+        groupService.listGroups(
+            offset = 0,
+            limit = 10,
+            bookmarked = true,
+            joined = null,
+            categories = null,
+            state = null,
+            interest = null,
+            keyword = null,
+            orderBy = null,
+            requesterId = 123L,
+        )
 
         // then
-        verify(groupRepository).findGroups(eq(0), eq(10), eq(null), eq(true), eq(null), eq(123L))
-        verify(groupRepository).countGroups(eq(null), eq(true), eq(123L))
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(null), eq(true),
+            isNull(), isNull(), isNull(), isNull(),
+            eq(null), eq(123L),
+        )
+        verify(groupRepository).countGroups(
+            eq(null), eq(true),
+            isNull(), isNull(), isNull(), isNull(),
+            eq(123L),
+        )
     }
 
     @Test
@@ -49,13 +102,25 @@ class GroupServiceTest {
             limit = 6,
             bookmarked = null,
             joined = true,
+            categories = null,
+            state = null,
+            interest = null,
+            keyword = null,
             orderBy = GroupOrderBy.CHANGED_AT,
             requesterId = 123L,
         )
 
         // then
-        verify(groupRepository).findGroups(eq(0), eq(6), eq(true), eq(null), eq(GroupOrderBy.CHANGED_AT), eq(123L))
-        verify(groupRepository).countGroups(eq(true), eq(null), eq(123L))
+        verify(groupRepository).findGroups(
+            eq(0), eq(6), eq(true), eq(null),
+            isNull(), isNull(), isNull(), isNull(),
+            eq(GroupOrderBy.CHANGED_AT), eq(123L),
+        )
+        verify(groupRepository).countGroups(
+            eq(true), eq(null),
+            isNull(), isNull(), isNull(), isNull(),
+            eq(123L),
+        )
     }
 
     @Test
@@ -66,12 +131,283 @@ class GroupServiceTest {
             limit = 10,
             bookmarked = true,
             joined = true,
+            categories = null,
+            state = null,
+            interest = null,
+            keyword = null,
             orderBy = GroupOrderBy.CHANGED_AT,
             requesterId = 123L,
         )
 
         // then
-        verify(groupRepository).findGroups(eq(0), eq(10), eq(true), eq(true), eq(GroupOrderBy.CHANGED_AT), eq(123L))
-        verify(groupRepository).countGroups(eq(true), eq(true), eq(123L))
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(true), eq(true),
+            isNull(), isNull(), isNull(), isNull(),
+            eq(GroupOrderBy.CHANGED_AT), eq(123L),
+        )
+        verify(groupRepository).countGroups(
+            eq(true), eq(true),
+            isNull(), isNull(), isNull(), isNull(),
+            eq(123L),
+        )
+    }
+
+    // --- 카테고리 필터 테스트 ---
+
+    @Test
+    fun `category=study로 조회하면 스터디 카테고리를 Repository에 전달한다`() {
+        // when
+        groupService.listGroups(
+            offset = 0,
+            limit = 10,
+            bookmarked = null,
+            joined = null,
+            categories = listOf("study"),
+            state = null,
+            interest = null,
+            keyword = null,
+            orderBy = null,
+            requesterId = 1L,
+        )
+
+        // then
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(null), eq(null),
+            eq(listOf(GroupCategory.STUDY)), isNull(), isNull(), isNull(),
+            eq(null), eq(1L),
+        )
+    }
+
+    @Test
+    fun `category=study,project로 조회하면 두 카테고리를 Repository에 전달한다`() {
+        // when
+        groupService.listGroups(
+            offset = 0,
+            limit = 10,
+            bookmarked = null,
+            joined = null,
+            categories = listOf("study", "project"),
+            state = null,
+            interest = null,
+            keyword = null,
+            orderBy = null,
+            requesterId = 1L,
+        )
+
+        // then
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(null), eq(null),
+            eq(listOf(GroupCategory.STUDY, GroupCategory.PROJECT)), isNull(), isNull(), isNull(),
+            eq(null), eq(1L),
+        )
+    }
+
+    @Test
+    fun `category 파라미터에 유효하지 않은 값을 전달하면 BadRequestException을 발생시킨다`() {
+        // when & then
+        val exception =
+            assertThrows<BadRequestException> {
+                groupService.listGroups(
+                    offset = 0,
+                    limit = 10,
+                    bookmarked = null,
+                    joined = null,
+                    categories = listOf("invalid_category"),
+                    state = null,
+                    interest = null,
+                    keyword = null,
+                    orderBy = null,
+                    requesterId = 1L,
+                )
+            }
+
+        assertTrue(exception.message.contains("invalid_category"))
+    }
+
+    // --- 상태 필터 테스트 ---
+
+    @Test
+    fun `state=progress로 조회하면 진행 중 상태를 Repository에 전달한다`() {
+        // when
+        groupService.listGroups(
+            offset = 0,
+            limit = 10,
+            bookmarked = null,
+            joined = null,
+            categories = null,
+            state = "progress",
+            interest = null,
+            keyword = null,
+            orderBy = null,
+            requesterId = 1L,
+        )
+
+        // then
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(null), eq(null),
+            isNull(), eq(GroupState.PROGRESS), isNull(), isNull(),
+            eq(null), eq(1L),
+        )
+    }
+
+    @Test
+    fun `state=end-success로 조회하면 종료 성공 상태를 Repository에 전달한다`() {
+        // when
+        groupService.listGroups(
+            offset = 0,
+            limit = 10,
+            bookmarked = null,
+            joined = null,
+            categories = null,
+            state = "end-success",
+            interest = null,
+            keyword = null,
+            orderBy = null,
+            requesterId = 1L,
+        )
+
+        // then
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(null), eq(null),
+            isNull(), eq(GroupState.END_SUCCESS), isNull(), isNull(),
+            eq(null), eq(1L),
+        )
+    }
+
+    @Test
+    fun `state 파라미터에 유효하지 않은 값을 전달하면 BadRequestException을 발생시킨다`() {
+        // when & then
+        val exception =
+            assertThrows<BadRequestException> {
+                groupService.listGroups(
+                    offset = 0,
+                    limit = 10,
+                    bookmarked = null,
+                    joined = null,
+                    categories = null,
+                    state = "invalid_state",
+                    interest = null,
+                    keyword = null,
+                    orderBy = null,
+                    requesterId = 1L,
+                )
+            }
+
+        assertTrue(exception.message.contains("invalid_state"))
+    }
+
+    // --- interest / keyword 필터 테스트 ---
+
+    @Test
+    fun `interest 값을 그대로 Repository에 전달한다`() {
+        // when
+        groupService.listGroups(
+            offset = 0,
+            limit = 10,
+            bookmarked = null,
+            joined = null,
+            categories = null,
+            state = null,
+            interest = "웹",
+            keyword = null,
+            orderBy = null,
+            requesterId = 1L,
+        )
+
+        // then
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(null), eq(null),
+            isNull(), isNull(), eq("웹"), isNull(),
+            eq(null), eq(1L),
+        )
+    }
+
+    @Test
+    fun `keyword 값을 그대로 Repository에 전달한다`() {
+        // when
+        groupService.listGroups(
+            offset = 0,
+            limit = 10,
+            bookmarked = null,
+            joined = null,
+            categories = null,
+            state = null,
+            interest = null,
+            keyword = "Spring",
+            orderBy = null,
+            requesterId = 1L,
+        )
+
+        // then
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(null), eq(null),
+            isNull(), isNull(), isNull(), eq("Spring"),
+            eq(null), eq(1L),
+        )
+    }
+
+    // --- 복합 필터 테스트 ---
+
+    @Test
+    fun `여러 필터를 동시에 사용할 수 있다`() {
+        // when
+        groupService.listGroups(
+            offset = 0,
+            limit = 10,
+            bookmarked = null,
+            joined = null,
+            categories = listOf("study", "project"),
+            state = "progress",
+            interest = "웹",
+            keyword = "Spring",
+            orderBy = GroupOrderBy.CHANGED_AT,
+            requesterId = 1L,
+        )
+
+        // then
+        verify(groupRepository).findGroups(
+            eq(0), eq(10), eq(null), eq(null),
+            eq(listOf(GroupCategory.STUDY, GroupCategory.PROJECT)),
+            eq(GroupState.PROGRESS),
+            eq("웹"),
+            eq("Spring"),
+            eq(GroupOrderBy.CHANGED_AT), eq(1L),
+        )
+        verify(groupRepository).countGroups(
+            eq(null), eq(null),
+            eq(listOf(GroupCategory.STUDY, GroupCategory.PROJECT)),
+            eq(GroupState.PROGRESS),
+            eq("웹"),
+            eq("Spring"),
+            eq(1L),
+        )
+    }
+
+    @Test
+    fun `count는 페이지네이션과 무관하게 필터 조건에 맞는 전체 그룹 수를 반환한다`() {
+        // given
+        given(
+            groupRepository.countGroups(
+                eq(null), eq(null), eq(listOf(GroupCategory.STUDY)), eq(GroupState.PROGRESS), eq(null), eq(null), eq(1L)
+            ),
+        ).willReturn(42L)
+
+        // when
+        val result =
+            groupService.listGroups(
+                offset = 20,
+                limit = 5,
+                bookmarked = null,
+                joined = null,
+                categories = listOf("study"),
+                state = "progress",
+                interest = null,
+                keyword = null,
+                orderBy = null,
+                requesterId = 1L,
+            )
+
+        // then
+        assertEquals(42L, result.count)
     }
 }


### PR DESCRIPTION
## 작업 개요
- 그룹 목록을 조회하는 API에 다중 조건 필터링(`category`, `state`, `interest`)과 키워드 검색(`keyword`) 기능을 추가했습니다.
- QueryDSL을 활용해 복잡한 동적 쿼리를 안정적으로 생성하고, 페이징(`offset`, `limit`)과 함께 데이터 조회 및 전체 개수(Count)를 분리하여 구현했습니다.

## 상세 작업 내역
1. **Controller (`GroupController`)**
   - 다중 선택이 가능한 `category`를 `List<String>`으로 받도록 구현
   - `state`, `interest`, `keyword` 등의 선택적 쿼리 파라미터 추가

2. **Service (`GroupService`)**
   - 클라이언트에서 넘어온 문자열(String) 파라미터를 도메인 Enum(`GroupCategory`, `GroupState`)으로 안전하게 변환
   - 유효하지 않은 값이 들어올 경우 `BadRequestException` 예외 처리 구현
   
3. **Repository (`GroupRepositoryImpl` - QueryDSL)**
   - **Category**: `in` 절을 사용하여 여러 카테고리 동시 검색 지원
   - **State**: `eq`를 통한 단일 상태 매칭
   - **Interest**: 파이프(`|`) 구분자로 저장된 데이터 패턴을 고려하여 4가지 케이스(`exact`, `startsWith`, `contains`, `endsWith`)로 정확한 관심사 필터링 구현
   - **Keyword**: `title`, `purpose`, `technology` 컬럼을 대상으로 `containsIgnoreCase`(Like '%...%') OR 검색 구현

4. **Test (`GroupServiceTest`)**
   - 각각의 단일 필터 조건과 복합 필터 조건에 대한 Repository 호출 파라미터 검증 완료
   - Enum 파싱 예외 상황에 대한 단위 테스트 추가

## 테스트 결과
- `./gradlew test --tests *GroupServiceTest*` 통과 완료 (`BUILD SUCCESSFUL`)
- 정상 및 예외 케이스(잘못된 카테고리/상태 값) 모두 예상대로 동작함

## 논의 사항
- 현재 `interest` 필드는 데이터베이스에 `|` 구분자로 직렬화되어 있어 부분 일치를 위한 Like 쿼리로 구현했습니다. 
- 키워드 검색(`keyword`)의 경우 양방향 와일드카드(`%keyword%`)를 사용하고 있습니다. 향후 데이터가 많아질 경우 성능 최적화(인덱스 변경 등) 논의가 필요할 수 있습니다.