### PR TITLE
feat: 가입신청서 기능 구현 관련 엔티티 정의

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ test-results/
 *-ref
 
 .env
+.obsidian/
+

--- a/src/main/kotlin/com/sight/domain/application/ApplicationComment.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationComment.kt
@@ -1,0 +1,34 @@
+package com.sight.domain.application
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "application_comment")
+data class ApplicationComment(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "application_form_id", nullable = false, length = 100)
+    val applicationFormId: String,
+
+    @Column(name = "author_user_id", nullable = false)
+    val authorUserId: Long,
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    val content: String,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/application/ApplicationContent.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationContent.kt
@@ -1,0 +1,34 @@
+package com.sight.domain.application
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "application_content")
+data class ApplicationContent(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "application_form_id", nullable = false, length = 100)
+    val applicationFormId: String,
+
+    @Column(name = "question_id", nullable = false, length = 100)
+    val questionId: String,
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    val content: String,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/application/ApplicationForm.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationForm.kt
@@ -1,0 +1,40 @@
+package com.sight.domain.application
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "application_form")
+data class ApplicationForm(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "info21_id", nullable = false, length = 100)
+    val info21Id: String,
+
+    @Column(name = "submittee", nullable = false, length = 255)
+    val submittee: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 50)
+    val status: ApplicationFormStatus,
+
+    @Column(name = "assigned_user_id", nullable = true)
+    val assignedUserId: Long? = null,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/application/ApplicationFormAuthToken.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationFormAuthToken.kt
@@ -1,0 +1,29 @@
+package com.sight.domain.application
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "application_form_auth_token")
+data class ApplicationFormAuthToken(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "application_form_id", nullable = false, length = 100)
+    val applicationFormId: String,
+
+    @Column(name = "token", nullable = false, length = 255)
+    val token: String,
+
+    @Column(name = "expired_at", nullable = false)
+    val expiredAt: LocalDateTime,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/application/ApplicationFormStatus.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationFormStatus.kt
@@ -1,0 +1,9 @@
+package com.sight.domain.application
+
+enum class ApplicationFormStatus {
+    DRAFT,
+    SUBMITTED,
+    PASSED,
+    REJECTED,
+    SUSPENDED,
+}

--- a/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
@@ -1,0 +1,40 @@
+package com.sight.domain.application
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "application_question")
+data class ApplicationQuestion(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "title", nullable = false, length = 255)
+    val title: String,
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    val description: String,
+
+    @Column(name = "min_length", nullable = false)
+    val minLength: Int,
+
+    @Column(name = "`order`", nullable = true)
+    val order: Int? = null,
+
+    @Column(name = "is_exposed", nullable = false, columnDefinition = "TINYINT")
+    val isExposed: Boolean,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/application/InterviewAvailableTime.kt
+++ b/src/main/kotlin/com/sight/domain/application/InterviewAvailableTime.kt
@@ -1,0 +1,26 @@
+package com.sight.domain.application
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "interview_available_time")
+data class InterviewAvailableTime(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "application_form_id", nullable = false, length = 100)
+    val applicationFormId: String,
+
+    @Column(name = "available_at", nullable = false, length = 50)
+    val availableAt: String,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/application/UserRegistrationRequest.kt
+++ b/src/main/kotlin/com/sight/domain/application/UserRegistrationRequest.kt
@@ -1,0 +1,34 @@
+package com.sight.domain.application
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "user_registration_request")
+data class UserRegistrationRequest(
+    @Id
+    @Column(name = "id", nullable = false, length = 100)
+    val id: String,
+
+    @Column(name = "requested_user_id", nullable = false)
+    val requestedUserId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 50)
+    val status: UserRegistrationRequestStatus,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/sight/domain/application/UserRegistrationRequestStatus.kt
+++ b/src/main/kotlin/com/sight/domain/application/UserRegistrationRequestStatus.kt
@@ -1,0 +1,6 @@
+package com.sight.domain.application
+
+enum class UserRegistrationRequestStatus {
+    PENDING,
+    APPROVED,
+}


### PR DESCRIPTION
- 가입신청서 기능 구현 관련 엔티티를 정의합니다.
- 별도 FK는 정의하지 않습니다.

```mermaid
erDiagram
    ApplicationForm ||--o{ ApplicationContent : "포함한다 (1:N)"
    ApplicationForm ||--o{ InterviewAvailableTime : "선택한다 (1:N)"
    ApplicationForm ||--o{ ApplicationComment : "가진다 (1:N)"
    ApplicationForm ||--o{ ApplicationFormAuthToken : "인증한다 (1:N)"
    ApplicationQuestion ||--o{ ApplicationContent : "참조된다 (1:N)"
    
    ApplicationForm {
        string id PK
        string info21Id "info21 아이디"
        string submittee "제출자 학과 및 이름"
        string status "상태 (임시저장/제출됨/합격/불합격/중단)"
        bigint assignedUserId "담당자 운영진의 유저ID"
        datetime createdAt
        datetime updatedAt
    }

    ApplicationContent {
        string id PK
        string applicationFormId FK "가입신청서 ID"
        string questionId FK "가입신청서 문항 ID"
        text content "내용"
        datetime createdAt
        datetime updatedAt
    }

    InterviewAvailableTime {
        string id PK
        string applicationFormId FK "가입신청서 ID"
        string availableAt "날짜 및 시간 (yyyy-MM-dd HH:mm (KST))"
        datetime createdAt
    }

    ApplicationComment {
        string id PK
        string applicationFormId FK "가입신청서 ID"
        bigint authorUserId "작성자의 유저 ID"
        text content "내용"
        datetime createdAt
        datetime updatedAt
    }

    ApplicationQuestion {
        string id PK
        string title "제목"
        text description "설명"
        int minLength "최소 글자 수"
        int order "순서 (NULL)"
        boolean isExposed "노출 여부"
        datetime createdAt
        datetime updatedAt
    }

    UserRegistrationRequest {
        string id PK
        bigint requestedUserId "요청한 유저 ID"
        string status "상태 (대기중/승인)"
        datetime createdAt
        datetime updatedAt
    }
    
    ApplicationFormAuthToken {
		    string id PK
		    string applicationFormId FK
		    string token
		    datetime expiredAt
			  datetime createdAt
    }
```