### PR TITLE
feat: 가입신청서 초안 생성 및 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sight/config/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.sight.config
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -39,6 +40,8 @@ class SecurityConfig {
                 }
                 .authorizeHttpRequests { auth ->
                     auth.requestMatchers("/ping", "/actuator/**", "/test/public", "/error")
+                        .permitAll()
+                        .requestMatchers(HttpMethod.POST, "/application-forms")
                         .permitAll()
                         .anyRequest()
                         .authenticated()

--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -35,8 +35,7 @@ class ApplicationFormController(
                 draft.interviewAvailableTimes.map { availableTime ->
                     CreateApplicationFormDraftResponse.InterviewAvailableTimeResponse(
                         id = availableTime.id,
-                        date = availableTime.date,
-                        time = availableTime.time,
+                        availableAt = availableTime.availableAt,
                         createdAt = availableTime.createdAt,
                     )
                 },

--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -1,0 +1,57 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.CreateApplicationFormDraftRequest
+import com.sight.controllers.http.dto.CreateApplicationFormDraftResponse
+import com.sight.service.ApplicationFormService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ApplicationFormController(
+    private val applicationFormService: ApplicationFormService,
+) {
+    @PostMapping("/application-forms")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createDraft(
+        @Valid @RequestBody request: CreateApplicationFormDraftRequest,
+    ): CreateApplicationFormDraftResponse {
+        val draft =
+            applicationFormService.createDraft(
+                info21Id = request.info21Id,
+                info21Password = request.info21Password,
+            )
+
+        return CreateApplicationFormDraftResponse(
+            id = draft.id,
+            info21Id = draft.info21Id,
+            submittee = draft.submittee,
+            token = draft.token,
+            status = draft.status,
+            interviewAvailableTimes =
+                draft.interviewAvailableTimes.map { availableTime ->
+                    CreateApplicationFormDraftResponse.InterviewAvailableTimeResponse(
+                        id = availableTime.id,
+                        date = availableTime.date,
+                        time = availableTime.time,
+                        createdAt = availableTime.createdAt,
+                    )
+                },
+            contents =
+                draft.contents.map { content ->
+                    CreateApplicationFormDraftResponse.ApplicationContentResponse(
+                        id = content.id,
+                        questionId = content.questionId,
+                        content = content.content,
+                        createdAt = content.createdAt,
+                        updatedAt = content.updatedAt,
+                    )
+                },
+            createdAt = draft.createdAt,
+            updatedAt = draft.updatedAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationFormDraftRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationFormDraftRequest.kt
@@ -1,0 +1,10 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreateApplicationFormDraftRequest(
+    @field:NotBlank
+    val info21Id: String,
+    @field:NotBlank
+    val info21Password: String,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationFormDraftResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationFormDraftResponse.kt
@@ -16,8 +16,7 @@ data class CreateApplicationFormDraftResponse(
 ) {
     data class InterviewAvailableTimeResponse(
         val id: String,
-        val date: String,
-        val time: String,
+        val availableAt: String,
         val createdAt: LocalDateTime,
     )
 

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationFormDraftResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationFormDraftResponse.kt
@@ -1,0 +1,31 @@
+package com.sight.controllers.http.dto
+
+import com.sight.domain.application.ApplicationFormStatus
+import java.time.LocalDateTime
+
+data class CreateApplicationFormDraftResponse(
+    val id: String,
+    val info21Id: String,
+    val submittee: String,
+    val token: String,
+    val status: ApplicationFormStatus,
+    val interviewAvailableTimes: List<InterviewAvailableTimeResponse>,
+    val contents: List<ApplicationContentResponse>,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    data class InterviewAvailableTimeResponse(
+        val id: String,
+        val date: String,
+        val time: String,
+        val createdAt: LocalDateTime,
+    )
+
+    data class ApplicationContentResponse(
+        val id: String,
+        val questionId: String,
+        val content: String,
+        val createdAt: LocalDateTime,
+        val updatedAt: LocalDateTime,
+    )
+}

--- a/src/main/kotlin/com/sight/domain/application/InterviewAvailableTime.kt
+++ b/src/main/kotlin/com/sight/domain/application/InterviewAvailableTime.kt
@@ -17,6 +17,7 @@ data class InterviewAvailableTime(
     @Column(name = "application_form_id", nullable = false, length = 100)
     val applicationFormId: String,
 
+    // Format: yyyy-MM-dd HH:mm; timezone: KST
     @Column(name = "available_at", nullable = false, length = 50)
     val availableAt: String,
 

--- a/src/main/kotlin/com/sight/repository/ApplicationContentRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ApplicationContentRepository.kt
@@ -1,0 +1,8 @@
+package com.sight.repository
+
+import com.sight.domain.application.ApplicationContent
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ApplicationContentRepository : JpaRepository<ApplicationContent, String> {
+    fun findAllByApplicationFormId(applicationFormId: String): List<ApplicationContent>
+}

--- a/src/main/kotlin/com/sight/repository/ApplicationFormAuthTokenRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ApplicationFormAuthTokenRepository.kt
@@ -1,0 +1,6 @@
+package com.sight.repository
+
+import com.sight.domain.application.ApplicationFormAuthToken
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ApplicationFormAuthTokenRepository : JpaRepository<ApplicationFormAuthToken, String>

--- a/src/main/kotlin/com/sight/repository/ApplicationFormRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ApplicationFormRepository.kt
@@ -1,0 +1,12 @@
+package com.sight.repository
+
+import com.sight.domain.application.ApplicationForm
+import com.sight.domain.application.ApplicationFormStatus
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ApplicationFormRepository : JpaRepository<ApplicationForm, String> {
+    fun findFirstByInfo21IdAndStatusInOrderByUpdatedAtDesc(
+        info21Id: String,
+        statuses: Collection<ApplicationFormStatus>,
+    ): ApplicationForm?
+}

--- a/src/main/kotlin/com/sight/repository/ApplicationQuestionRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ApplicationQuestionRepository.kt
@@ -1,0 +1,8 @@
+package com.sight.repository
+
+import com.sight.domain.application.ApplicationQuestion
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ApplicationQuestionRepository : JpaRepository<ApplicationQuestion, String> {
+    fun findAllByIsExposedTrue(): List<ApplicationQuestion>
+}

--- a/src/main/kotlin/com/sight/repository/InterviewAvailableTimeRepository.kt
+++ b/src/main/kotlin/com/sight/repository/InterviewAvailableTimeRepository.kt
@@ -1,0 +1,8 @@
+package com.sight.repository
+
+import com.sight.domain.application.InterviewAvailableTime
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface InterviewAvailableTimeRepository : JpaRepository<InterviewAvailableTime, String> {
+    fun findAllByApplicationFormId(applicationFormId: String): List<InterviewAvailableTime>
+}

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -137,5 +137,4 @@ class ApplicationFormService(
             }
         }
     }
-
 }

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -68,11 +68,9 @@ class ApplicationFormService(
             status = applicationForm.status,
             interviewAvailableTimes =
                 interviewAvailableTimes.map { availableTime ->
-                    val (date, time) = splitAvailableAt(availableTime.availableAt)
                     ApplicationFormDraftDto.InterviewAvailableTimeDto(
                         id = availableTime.id,
-                        date = date,
-                        time = time,
+                        availableAt = availableTime.availableAt,
                         createdAt = availableTime.createdAt,
                     )
                 },
@@ -140,13 +138,4 @@ class ApplicationFormService(
         }
     }
 
-    private fun splitAvailableAt(availableAt: String): Pair<String, String> {
-        val normalized = availableAt.replace("T", " ")
-        val parts = normalized.split(" ", limit = 2)
-        return if (parts.size == 2) {
-            parts[0] to parts[1]
-        } else {
-            availableAt to ""
-        }
-    }
 }

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -1,0 +1,152 @@
+package com.sight.service
+
+import com.github.f4b6a3.ulid.UlidCreator
+import com.sight.core.exception.UnauthorizedException
+import com.sight.core.info21.Info21AuthClient
+import com.sight.core.info21.Info21AuthRequest
+import com.sight.domain.application.ApplicationContent
+import com.sight.domain.application.ApplicationForm
+import com.sight.domain.application.ApplicationFormAuthToken
+import com.sight.domain.application.ApplicationFormStatus
+import com.sight.domain.application.ApplicationQuestion
+import com.sight.repository.ApplicationContentRepository
+import com.sight.repository.ApplicationFormAuthTokenRepository
+import com.sight.repository.ApplicationFormRepository
+import com.sight.repository.ApplicationQuestionRepository
+import com.sight.repository.InterviewAvailableTimeRepository
+import com.sight.service.dto.ApplicationFormDraftDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.security.SecureRandom
+import java.time.LocalDateTime
+
+@Service
+class ApplicationFormService(
+    private val info21AuthClient: Info21AuthClient,
+    private val applicationFormRepository: ApplicationFormRepository,
+    private val applicationQuestionRepository: ApplicationQuestionRepository,
+    private val applicationContentRepository: ApplicationContentRepository,
+    private val applicationFormAuthTokenRepository: ApplicationFormAuthTokenRepository,
+    private val interviewAvailableTimeRepository: InterviewAvailableTimeRepository,
+) {
+    private val reusableStatuses = listOf(ApplicationFormStatus.DRAFT, ApplicationFormStatus.SUBMITTED)
+    private val tokenCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    private val secureRandom = SecureRandom()
+
+    @Transactional
+    fun createDraft(
+        info21Id: String,
+        info21Password: String,
+    ): ApplicationFormDraftDto {
+        val authResponse =
+            info21AuthClient.authenticate(
+                Info21AuthRequest(
+                    info21Id = info21Id,
+                    info21Password = info21Password,
+                ),
+            )
+        if (authResponse.code != 200) {
+            throw UnauthorizedException("Info21 인증에 실패했습니다")
+        }
+
+        val applicationForm =
+            applicationFormRepository.findFirstByInfo21IdAndStatusInOrderByUpdatedAtDesc(
+                info21Id = info21Id,
+                statuses = reusableStatuses,
+            ) ?: createApplicationForm(info21Id, authResponse.data.name)
+
+        val token = saveAuthToken(applicationForm.id)
+        val contents = applicationContentRepository.findAllByApplicationFormId(applicationForm.id)
+        val interviewAvailableTimes =
+            interviewAvailableTimeRepository.findAllByApplicationFormId(applicationForm.id)
+
+        return ApplicationFormDraftDto(
+            id = applicationForm.id,
+            info21Id = applicationForm.info21Id,
+            submittee = applicationForm.submittee,
+            token = token.token,
+            status = applicationForm.status,
+            interviewAvailableTimes =
+                interviewAvailableTimes.map { availableTime ->
+                    val (date, time) = splitAvailableAt(availableTime.availableAt)
+                    ApplicationFormDraftDto.InterviewAvailableTimeDto(
+                        id = availableTime.id,
+                        date = date,
+                        time = time,
+                        createdAt = availableTime.createdAt,
+                    )
+                },
+            contents =
+                contents.map { content ->
+                    ApplicationFormDraftDto.ApplicationContentDto(
+                        id = content.id,
+                        questionId = content.questionId,
+                        content = content.content,
+                        createdAt = content.createdAt,
+                        updatedAt = content.updatedAt,
+                    )
+                },
+            createdAt = applicationForm.createdAt,
+            updatedAt = applicationForm.updatedAt,
+        )
+    }
+
+    private fun createApplicationForm(
+        info21Id: String,
+        submittee: String,
+    ): ApplicationForm {
+        val applicationForm =
+            ApplicationForm(
+                id = UlidCreator.getUlid().toString(),
+                info21Id = info21Id,
+                submittee = submittee,
+                status = ApplicationFormStatus.DRAFT,
+            )
+        applicationFormRepository.save(applicationForm)
+
+        val contents =
+            applicationQuestionRepository.findAllByIsExposedTrue()
+                .sortedWith(compareBy<ApplicationQuestion> { it.order ?: Int.MAX_VALUE }.thenBy { it.createdAt })
+                .map { question ->
+                    ApplicationContent(
+                        id = UlidCreator.getUlid().toString(),
+                        applicationFormId = applicationForm.id,
+                        questionId = question.id,
+                        content = "",
+                    )
+                }
+        applicationContentRepository.saveAll(contents)
+
+        return applicationForm
+    }
+
+    private fun saveAuthToken(applicationFormId: String): ApplicationFormAuthToken {
+        val token =
+            ApplicationFormAuthToken(
+                id = UlidCreator.getUlid().toString(),
+                applicationFormId = applicationFormId,
+                token = generateToken(),
+                expiredAt = LocalDateTime.now().plusHours(24),
+            )
+        applicationFormAuthTokenRepository.save(token)
+        return token
+    }
+
+    private fun generateToken(): String {
+        return buildString {
+            repeat(64) {
+                append(tokenCharacters[secureRandom.nextInt(tokenCharacters.length)])
+            }
+        }
+    }
+
+    private fun splitAvailableAt(availableAt: String): Pair<String, String> {
+        val normalized = availableAt.replace("T", " ")
+        val parts = normalized.split(" ", limit = 2)
+        return if (parts.size == 2) {
+            parts[0] to parts[1]
+        } else {
+            availableAt to ""
+        }
+    }
+}

--- a/src/main/kotlin/com/sight/service/dto/ApplicationFormDraftDto.kt
+++ b/src/main/kotlin/com/sight/service/dto/ApplicationFormDraftDto.kt
@@ -1,0 +1,31 @@
+package com.sight.service.dto
+
+import com.sight.domain.application.ApplicationFormStatus
+import java.time.LocalDateTime
+
+data class ApplicationFormDraftDto(
+    val id: String,
+    val info21Id: String,
+    val submittee: String,
+    val token: String,
+    val status: ApplicationFormStatus,
+    val interviewAvailableTimes: List<InterviewAvailableTimeDto>,
+    val contents: List<ApplicationContentDto>,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    data class InterviewAvailableTimeDto(
+        val id: String,
+        val date: String,
+        val time: String,
+        val createdAt: LocalDateTime,
+    )
+
+    data class ApplicationContentDto(
+        val id: String,
+        val questionId: String,
+        val content: String,
+        val createdAt: LocalDateTime,
+        val updatedAt: LocalDateTime,
+    )
+}

--- a/src/main/kotlin/com/sight/service/dto/ApplicationFormDraftDto.kt
+++ b/src/main/kotlin/com/sight/service/dto/ApplicationFormDraftDto.kt
@@ -16,8 +16,7 @@ data class ApplicationFormDraftDto(
 ) {
     data class InterviewAvailableTimeDto(
         val id: String,
-        val date: String,
-        val time: String,
+        val availableAt: String,
         val createdAt: LocalDateTime,
     )
 

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -1,0 +1,194 @@
+package com.sight.service
+
+import com.sight.core.exception.UnauthorizedException
+import com.sight.core.info21.Info21AuthClient
+import com.sight.core.info21.StuauthData
+import com.sight.core.info21.StuauthMajor
+import com.sight.core.info21.StuauthResponse
+import com.sight.domain.application.ApplicationContent
+import com.sight.domain.application.ApplicationForm
+import com.sight.domain.application.ApplicationFormStatus
+import com.sight.domain.application.ApplicationQuestion
+import com.sight.domain.application.InterviewAvailableTime
+import com.sight.repository.ApplicationContentRepository
+import com.sight.repository.ApplicationFormAuthTokenRepository
+import com.sight.repository.ApplicationFormRepository
+import com.sight.repository.ApplicationQuestionRepository
+import com.sight.repository.InterviewAvailableTimeRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import java.time.LocalDateTime
+
+class ApplicationFormServiceTest {
+    private val info21AuthClient = mock<Info21AuthClient>()
+    private val applicationFormRepository = mock<ApplicationFormRepository>()
+    private val applicationQuestionRepository = mock<ApplicationQuestionRepository>()
+    private val applicationContentRepository = mock<ApplicationContentRepository>()
+    private val applicationFormAuthTokenRepository = mock<ApplicationFormAuthTokenRepository>()
+    private val interviewAvailableTimeRepository = mock<InterviewAvailableTimeRepository>()
+    private lateinit var service: ApplicationFormService
+
+    @BeforeEach
+    fun setUp() {
+        service =
+            ApplicationFormService(
+                info21AuthClient = info21AuthClient,
+                applicationFormRepository = applicationFormRepository,
+                applicationQuestionRepository = applicationQuestionRepository,
+                applicationContentRepository = applicationContentRepository,
+                applicationFormAuthTokenRepository = applicationFormAuthTokenRepository,
+                interviewAvailableTimeRepository = interviewAvailableTimeRepository,
+            )
+    }
+
+    @Test
+    fun `createDraft는 Info21 인증 실패 시 UnauthorizedException을 던진다`() {
+        given(info21AuthClient.authenticate(any()))
+            .willReturn(stuauthResponse(code = 401))
+
+        assertThrows<UnauthorizedException> {
+            service.createDraft("2021999999", "wrong-password")
+        }
+    }
+
+    @Test
+    fun `createDraft는 기존 임시저장 신청서가 있으면 신청서를 새로 만들지 않고 토큰을 발급한다`() {
+        val applicationForm =
+            ApplicationForm(
+                id = "form-1",
+                info21Id = "2021999999",
+                submittee = "김테스트",
+                status = ApplicationFormStatus.DRAFT,
+            )
+        val content =
+            ApplicationContent(
+                id = "content-1",
+                applicationFormId = applicationForm.id,
+                questionId = "question-1",
+                content = "기존 답변",
+            )
+        val availableTime =
+            InterviewAvailableTime(
+                id = "time-1",
+                applicationFormId = applicationForm.id,
+                availableAt = "2026-06-01 10:00",
+            )
+
+        given(info21AuthClient.authenticate(any())).willReturn(stuauthResponse())
+        given(
+            applicationFormRepository.findFirstByInfo21IdAndStatusInOrderByUpdatedAtDesc(
+                eq("2021999999"),
+                eq(listOf(ApplicationFormStatus.DRAFT, ApplicationFormStatus.SUBMITTED)),
+            ),
+        ).willReturn(applicationForm)
+        given(applicationContentRepository.findAllByApplicationFormId(applicationForm.id)).willReturn(listOf(content))
+        given(interviewAvailableTimeRepository.findAllByApplicationFormId(applicationForm.id))
+            .willReturn(listOf(availableTime))
+
+        val result = service.createDraft("2021999999", "password")
+
+        assertEquals(applicationForm.id, result.id)
+        assertEquals("기존 답변", result.contents.single().content)
+        assertEquals("2026-06-01", result.interviewAvailableTimes.single().date)
+        assertEquals("10:00", result.interviewAvailableTimes.single().time)
+        assertEquals(64, result.token.length)
+        verify(applicationFormRepository, never()).save(any())
+        verify(applicationContentRepository, never()).saveAll(any<List<ApplicationContent>>())
+        verify(applicationFormAuthTokenRepository).save(any())
+    }
+
+    @Test
+    fun `createDraft는 기존 신청서가 없으면 노출 질문 기준으로 초안을 생성한다`() {
+        val firstQuestion =
+            ApplicationQuestion(
+                id = "question-1",
+                title = "자기소개",
+                description = "자기소개를 입력해주세요",
+                minLength = 10,
+                order = 2,
+                isExposed = true,
+                createdAt = LocalDateTime.now().minusDays(1),
+            )
+        val secondQuestion =
+            ApplicationQuestion(
+                id = "question-2",
+                title = "지원동기",
+                description = "지원동기를 입력해주세요",
+                minLength = 10,
+                order = 1,
+                isExposed = true,
+            )
+        val nullOrderQuestion =
+            ApplicationQuestion(
+                id = "question-3",
+                title = "기타",
+                description = "기타 내용을 입력해주세요",
+                minLength = 0,
+                order = null,
+                isExposed = true,
+            )
+
+        given(info21AuthClient.authenticate(any())).willReturn(stuauthResponse(name = "김테스트"))
+        given(
+            applicationFormRepository.findFirstByInfo21IdAndStatusInOrderByUpdatedAtDesc(
+                eq("2021999999"),
+                eq(listOf(ApplicationFormStatus.DRAFT, ApplicationFormStatus.SUBMITTED)),
+            ),
+        ).willReturn(null)
+        given(applicationQuestionRepository.findAllByIsExposedTrue())
+            .willReturn(listOf(firstQuestion, nullOrderQuestion, secondQuestion))
+        given(applicationContentRepository.findAllByApplicationFormId(any())).willReturn(emptyList())
+        given(interviewAvailableTimeRepository.findAllByApplicationFormId(any())).willReturn(emptyList())
+
+        val result = service.createDraft("2021999999", "password")
+
+        val formCaptor = argumentCaptor<ApplicationForm>()
+        val contentsCaptor = argumentCaptor<List<ApplicationContent>>()
+        verify(applicationFormRepository).save(formCaptor.capture())
+        verify(applicationContentRepository).saveAll(contentsCaptor.capture())
+        verify(applicationFormAuthTokenRepository).save(any())
+
+        assertEquals("2021999999", formCaptor.firstValue.info21Id)
+        assertEquals("김테스트", formCaptor.firstValue.submittee)
+        assertEquals(ApplicationFormStatus.DRAFT, formCaptor.firstValue.status)
+        assertEquals(formCaptor.firstValue.id, result.id)
+        assertEquals(64, result.token.length)
+        assertTrue(result.contents.isEmpty())
+        assertEquals(listOf("question-2", "question-1", "question-3"), contentsCaptor.firstValue.map { it.questionId })
+        assertTrue(contentsCaptor.firstValue.all { it.content == "" })
+    }
+
+    private fun stuauthResponse(
+        code: Int = 200,
+        name: String = "김테스트",
+    ): StuauthResponse {
+        return StuauthResponse(
+            code = code,
+            message = "OK",
+            data =
+                StuauthData(
+                    studentNumber = 2021999999,
+                    name = name,
+                    grade = 1,
+                    major =
+                        listOf(
+                            StuauthMajor(
+                                college = "소프트웨어융합대학",
+                                department = "컴퓨터공학부",
+                            ),
+                        ),
+                    phone = "010-0000-0000",
+                ),
+        )
+    }
+}

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -99,8 +99,7 @@ class ApplicationFormServiceTest {
 
         assertEquals(applicationForm.id, result.id)
         assertEquals("기존 답변", result.contents.single().content)
-        assertEquals("2026-06-01", result.interviewAvailableTimes.single().date)
-        assertEquals("10:00", result.interviewAvailableTimes.single().time)
+        assertEquals("2026-06-01 10:00", result.interviewAvailableTimes.single().availableAt)
         assertEquals(64, result.token.length)
         verify(applicationFormRepository, never()).save(any())
         verify(applicationContentRepository, never()).saveAll(any<List<ApplicationContent>>())


### PR DESCRIPTION
1. 주어진 `info21Id`와 `info21Password`로 info21 인증 요청하여 성공하는지 확인합니다. 실패 시 401.
2. 주어진 `info21Id`과 해당 값이 동일하며 `status`가 임시저장 혹은 제출됨 상태인 가입신청서 관련 데이터를 조회합니다.
3. 임의의 랜덤 64자 `token`을 생성하고, 이를 기반으로 `ApplicationFormAuthToken` 객체를 생성합니다. `expiredAt`은 현재로부터 24시간 더한 값을 넣습니다.
4. `ApplicationFormAuthToken`를 저장한다.
5. 2번에서 조회한 가입신청서가 존재하는 경우 201로 해당 정보를 반환합니다.
6. `ApplicationForm` 객체를 생성합니다 (`id` = ulid, `info21Id` = 입력값, `status` = 임시저장).
7. `ApplicationQuestion` 중 `isExposed`가 `true`인 목록을 조회합니다.
8. 해당 조회한 가입신청서 항목에 각각 1:1 대응되는 `ApplicationContent` 객체들을 생성합니다.
9. 생성한 `ApplicationForm`과 `ApplicationContent`를 저장합니다.
10. response body 형태에 맞춰 반환합니다.

### Query Parameters

- *(없음)*

### Request Body

- info21Id: string, required
- info21Password: string, required

### Status Code

- 201

### Response Body

- id: string
- info21Id: string
- submittee: string
- token: string
- status: string
- interviewAvailableTimes: object[]
    - id: string
    - availableAt: string
    - createdAt: string (ISO8601)
- contents: object[]
    - id: string
    - questionId: string
    - content: string
    - createdAt string (ISO8601)
    - updatedAt: string (ISO8601)
- createdAt: string (ISO8601)
- updatedAt: string (ISO8601)