### PR TITLE
feat: 가입신청서 불합격 처리 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -58,4 +58,18 @@ class ApplicationFormController(
         )
         return ResponseEntity.noContent().build()
     }
+
+    @Auth([UserRole.MANAGER])
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/application-forms/{applicationFormId}/reject")
+    fun rejectApplicationForm(
+        @PathVariable applicationFormId: String,
+        requester: Requester,
+    ): ResponseEntity<Void> {
+        applicationFormService.rejectApplicationForm(
+            applicationFormId = applicationFormId,
+            authorUserId = requester.userId,
+        )
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -81,4 +81,39 @@ class ApplicationFormService(
         // TODO: 쿠러그 회원 정보 생성
         // 합격 처리 시 쿠러그 회원(khlug_members) 정보를 생성해야 합니다.
     }
+
+    @Transactional
+    fun rejectApplicationForm(
+        applicationFormId: String,
+        authorUserId: Long,
+    ): ApplicationForm {
+        // 1. 주어진 applicationFormId로 ApplicationForm 엔티티를 조회합니다. 존재하지 않으면 404.
+        val applicationForm =
+            applicationFormRepository.findById(applicationFormId).orElseThrow {
+                NotFoundException("가입신청서를 찾을 수 없습니다: $applicationFormId")
+            }
+
+        // 2. 조회한 가입신청서의 status가 제출됨 상태인지 확인합니다. 이미 합격/불합격/중단 상태라면 422.
+        if (applicationForm.status != ApplicationFormStatus.SUBMITTED) {
+            throw UnprocessableEntityException("제출된 상태의 가입신청서만 불합격 처리할 수 있습니다: ${applicationForm.status}")
+        }
+
+        // 3. ApplicationComment 객체를 생성합니다.(id = ulid, applicationFormId = path parameter, authorUserId = 요청한 운영진 유저 ID, content = “가입신청서가 불합격 처리되었습니다.”)
+        val comment =
+            ApplicationComment(
+                id = UlidCreator.getUlid().toString(),
+                applicationFormId = applicationFormId,
+                authorUserId = authorUserId,
+                content = "가입신청서가 불합격 처리되었습니다.",
+            )
+
+        // 4. 생성한 댓글을 저장합니다.
+        applicationCommentRepository.save(comment)
+
+        // 5. 해당 가입신청서의 status를 불합격으로 변경합니다.
+        val updatedForm = applicationForm.copy(status = ApplicationFormStatus.REJECTED)
+
+        // 6. 저장합니다.
+        return applicationFormRepository.save(updatedForm)
+    }
 }

--- a/src/test/kotlin/com/sight/controllers/http/ApplicationFormControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/ApplicationFormControllerTest.kt
@@ -161,4 +161,44 @@ class ApplicationFormControllerTest {
             authorUserId = managerRequester.userId,
         )
     }
+
+    @Test
+    fun `가입 신청서 불합격 처리 API가 정상 작동하면 204 No Content를 반환한다`() {
+        // given
+        val applicationFormId = "form-ulid"
+        val managerRequester = Requester(userId = 12345L, role = UserRole.MANAGER)
+        val auth =
+            UsernamePasswordAuthenticationToken(
+                managerRequester,
+                null,
+                listOf(SimpleGrantedAuthority("ROLE_MANAGER")),
+            )
+        SecurityContextHolder.getContext().authentication = auth
+
+        val expectedForm =
+            ApplicationForm(
+                id = applicationFormId,
+                info21Id = "info21-id",
+                submittee = "홍길동",
+                status = ApplicationFormStatus.REJECTED,
+            )
+
+        given(
+            applicationFormService.rejectApplicationForm(
+                applicationFormId = applicationFormId,
+                authorUserId = managerRequester.userId,
+            ),
+        ).willReturn(expectedForm)
+
+        // when & then
+        mockMvc.perform(
+            patch("/application-forms/$applicationFormId/reject"),
+        )
+            .andExpect(status().isNoContent)
+
+        verify(applicationFormService).rejectApplicationForm(
+            applicationFormId = applicationFormId,
+            authorUserId = managerRequester.userId,
+        )
+    }
 }

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -193,4 +193,97 @@ class ApplicationFormServiceTest {
 
         verify(applicationFormRepository).findById(applicationFormId)
     }
+
+    @Test
+    fun `rejectApplicationForm는 가입 신청서가 존재하고 제출된 상태일 때 정상적으로 불합격 처리한다`() {
+        // given
+        val applicationFormId = "form-ulid"
+        val authorUserId = 12345L
+
+        val applicationForm =
+            ApplicationForm(
+                id = applicationFormId,
+                info21Id = "info21-id",
+                submittee = "홍길동",
+                status = ApplicationFormStatus.SUBMITTED,
+            )
+
+        val savedComment =
+            ApplicationComment(
+                id = "comment-ulid",
+                applicationFormId = applicationFormId,
+                authorUserId = authorUserId,
+                content = "가입신청서가 불합격 처리되었습니다.",
+            )
+
+        given(applicationFormRepository.findById(applicationFormId))
+            .willReturn(Optional.of(applicationForm))
+        given(applicationCommentRepository.save(any<ApplicationComment>()))
+            .willReturn(savedComment)
+        given(applicationFormRepository.save(any<ApplicationForm>()))
+            .willReturn(applicationForm.copy(status = ApplicationFormStatus.REJECTED))
+
+        // when
+        val result =
+            applicationFormService.rejectApplicationForm(
+                applicationFormId = applicationFormId,
+                authorUserId = authorUserId,
+            )
+
+        // then
+        assertNotNull(result)
+        assertEquals(ApplicationFormStatus.REJECTED, result.status)
+
+        verify(applicationFormRepository).findById(applicationFormId)
+        verify(applicationCommentRepository).save(any<ApplicationComment>())
+        verify(applicationFormRepository).save(any<ApplicationForm>())
+    }
+
+    @Test
+    fun `rejectApplicationForm는 존재하지 않는 가입 신청서인 경우 NotFoundException을 던진다`() {
+        // given
+        val applicationFormId = "non-existent-form"
+        val authorUserId = 12345L
+
+        given(applicationFormRepository.findById(applicationFormId))
+            .willReturn(Optional.empty())
+
+        // when & then
+        assertThrows<NotFoundException> {
+            applicationFormService.rejectApplicationForm(
+                applicationFormId = applicationFormId,
+                authorUserId = authorUserId,
+            )
+        }
+
+        verify(applicationFormRepository).findById(applicationFormId)
+    }
+
+    @Test
+    fun `rejectApplicationForm는 가입 신청서가 제출됨 상태가 아닌 경우 UnprocessableEntityException을 던진다`() {
+        // given
+        val applicationFormId = "form-ulid"
+        val authorUserId = 12345L
+
+        val applicationForm =
+            ApplicationForm(
+                id = applicationFormId,
+                info21Id = "info21-id",
+                submittee = "홍길동",
+                status = ApplicationFormStatus.REJECTED,
+            )
+
+        given(applicationFormRepository.findById(applicationFormId))
+            .willReturn(Optional.of(applicationForm))
+
+        // when & then
+        assertThrows<UnprocessableEntityException> {
+            applicationFormService.rejectApplicationForm(
+                applicationFormId = applicationFormId,
+                authorUserId = authorUserId,
+            )
+        }
+
+        verify(applicationFormRepository).findById(applicationFormId)
+    }
 }

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -456,7 +456,7 @@ class ApplicationFormServiceTest {
 
         // when
         val result =
-            applicationFormService.rejectApplicationForm(
+            service.rejectApplicationForm(
                 applicationFormId = applicationFormId,
                 authorUserId = authorUserId,
             )
@@ -481,7 +481,7 @@ class ApplicationFormServiceTest {
 
         // when & then
         assertThrows<NotFoundException> {
-            applicationFormService.rejectApplicationForm(
+            service.rejectApplicationForm(
                 applicationFormId = applicationFormId,
                 authorUserId = authorUserId,
             )
@@ -509,7 +509,7 @@ class ApplicationFormServiceTest {
 
         // when & then
         assertThrows<UnprocessableEntityException> {
-            applicationFormService.rejectApplicationForm(
+            service.rejectApplicationForm(
                 applicationFormId = applicationFormId,
                 authorUserId = authorUserId,
             )


### PR DESCRIPTION
가입신청서 불합격 처리 API 설계서 바탕으로 구현