### PR TITLE
feat: 가입신청서 담당자 운영진 배정 기능 추가

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -1,11 +1,17 @@
 package com.sight.controllers.http
 
+import com.sight.controllers.http.dto.AssignApplicationFormManagerRequest
 import com.sight.controllers.http.dto.CreateApplicationFormDraftRequest
 import com.sight.controllers.http.dto.CreateApplicationFormDraftResponse
+import com.sight.core.auth.Auth
+import com.sight.core.auth.UserRole
+import com.sight.core.exception.BadRequestException
 import com.sight.service.ApplicationFormService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -51,6 +57,23 @@ class ApplicationFormController(
                 },
             createdAt = draft.createdAt,
             updatedAt = draft.updatedAt,
+        )
+    }
+
+    @Auth([UserRole.MANAGER])
+    @PutMapping("/application-forms/{applicationFormId}/assignee")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun assignManager(
+        @PathVariable applicationFormId: String,
+        @Valid @RequestBody request: AssignApplicationFormManagerRequest,
+    ) {
+        val managerUserId =
+            request.managerUserId.toLongOrNull()
+                ?: throw BadRequestException("managerUserId는 숫자 문자열이어야 합니다")
+
+        applicationFormService.assignManager(
+            applicationFormId = applicationFormId,
+            managerUserId = managerUserId,
         )
     }
 }

--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -5,7 +5,6 @@ import com.sight.controllers.http.dto.CreateApplicationFormDraftRequest
 import com.sight.controllers.http.dto.CreateApplicationFormDraftResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.UserRole
-import com.sight.core.exception.BadRequestException
 import com.sight.service.ApplicationFormService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -67,13 +66,9 @@ class ApplicationFormController(
         @PathVariable applicationFormId: String,
         @Valid @RequestBody request: AssignApplicationFormManagerRequest,
     ) {
-        val managerUserId =
-            request.managerUserId.toLongOrNull()
-                ?: throw BadRequestException("managerUserId는 숫자 문자열이어야 합니다")
-
         applicationFormService.assignManager(
             applicationFormId = applicationFormId,
-            managerUserId = managerUserId,
+            managerUserId = request.managerUserId!!,
         )
     }
 }

--- a/src/main/kotlin/com/sight/controllers/http/dto/AssignApplicationFormManagerRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/AssignApplicationFormManagerRequest.kt
@@ -1,10 +1,8 @@
 package com.sight.controllers.http.dto
 
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.NotNull
 
 data class AssignApplicationFormManagerRequest(
-    @field:NotBlank
-    @field:Pattern(regexp = "\\d+")
-    val managerUserId: String,
+    @field:NotNull
+    val managerUserId: Long?,
 )

--- a/src/main/kotlin/com/sight/controllers/http/dto/AssignApplicationFormManagerRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/AssignApplicationFormManagerRequest.kt
@@ -1,0 +1,10 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class AssignApplicationFormManagerRequest(
+    @field:NotBlank
+    @field:Pattern(regexp = "\\d+")
+    val managerUserId: String,
+)

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -1,7 +1,9 @@
 package com.sight.service
 
 import com.github.f4b6a3.ulid.UlidCreator
+import com.sight.core.exception.NotFoundException
 import com.sight.core.exception.UnauthorizedException
+import com.sight.core.exception.UnprocessableEntityException
 import com.sight.core.info21.Info21AuthClient
 import com.sight.core.info21.Info21AuthRequest
 import com.sight.domain.application.ApplicationContent
@@ -14,6 +16,7 @@ import com.sight.repository.ApplicationFormAuthTokenRepository
 import com.sight.repository.ApplicationFormRepository
 import com.sight.repository.ApplicationQuestionRepository
 import com.sight.repository.InterviewAvailableTimeRepository
+import com.sight.repository.MemberRepository
 import com.sight.service.dto.ApplicationFormDraftDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,6 +31,7 @@ class ApplicationFormService(
     private val applicationContentRepository: ApplicationContentRepository,
     private val applicationFormAuthTokenRepository: ApplicationFormAuthTokenRepository,
     private val interviewAvailableTimeRepository: InterviewAvailableTimeRepository,
+    private val memberRepository: MemberRepository,
 ) {
     private val reusableStatuses = listOf(ApplicationFormStatus.DRAFT, ApplicationFormStatus.SUBMITTED)
     private val tokenCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
@@ -87,6 +91,25 @@ class ApplicationFormService(
             createdAt = applicationForm.createdAt,
             updatedAt = applicationForm.updatedAt,
         )
+    }
+
+    @Transactional
+    fun assignManager(
+        applicationFormId: String,
+        managerUserId: Long,
+    ) {
+        val manager =
+            memberRepository.findById(managerUserId)
+                .orElseThrow { UnprocessableEntityException("담당자로 배정할 운영진을 찾을 수 없습니다") }
+        if (!manager.manager) {
+            throw UnprocessableEntityException("담당자로 배정할 사용자가 운영진이 아닙니다")
+        }
+
+        val applicationForm =
+            applicationFormRepository.findById(applicationFormId)
+                .orElseThrow { NotFoundException("가입신청서를 찾을 수 없습니다") }
+
+        applicationFormRepository.save(applicationForm.copy(assignedUserId = managerUserId))
     }
 
     private fun createApplicationForm(

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -1,6 +1,8 @@
 package com.sight.service
 
+import com.sight.core.exception.NotFoundException
 import com.sight.core.exception.UnauthorizedException
+import com.sight.core.exception.UnprocessableEntityException
 import com.sight.core.info21.Info21AuthClient
 import com.sight.core.info21.StuauthData
 import com.sight.core.info21.StuauthMajor
@@ -10,11 +12,15 @@ import com.sight.domain.application.ApplicationForm
 import com.sight.domain.application.ApplicationFormStatus
 import com.sight.domain.application.ApplicationQuestion
 import com.sight.domain.application.InterviewAvailableTime
+import com.sight.domain.member.Member
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
 import com.sight.repository.ApplicationContentRepository
 import com.sight.repository.ApplicationFormAuthTokenRepository
 import com.sight.repository.ApplicationFormRepository
 import com.sight.repository.ApplicationQuestionRepository
 import com.sight.repository.InterviewAvailableTimeRepository
+import com.sight.repository.MemberRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -27,7 +33,10 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
 import java.time.LocalDateTime
+import java.util.Optional
 
 class ApplicationFormServiceTest {
     private val info21AuthClient = mock<Info21AuthClient>()
@@ -36,6 +45,7 @@ class ApplicationFormServiceTest {
     private val applicationContentRepository = mock<ApplicationContentRepository>()
     private val applicationFormAuthTokenRepository = mock<ApplicationFormAuthTokenRepository>()
     private val interviewAvailableTimeRepository = mock<InterviewAvailableTimeRepository>()
+    private val memberRepository = mock<MemberRepository>()
     private lateinit var service: ApplicationFormService
 
     @BeforeEach
@@ -48,6 +58,7 @@ class ApplicationFormServiceTest {
                 applicationContentRepository = applicationContentRepository,
                 applicationFormAuthTokenRepository = applicationFormAuthTokenRepository,
                 interviewAvailableTimeRepository = interviewAvailableTimeRepository,
+                memberRepository = memberRepository,
             )
     }
 
@@ -167,6 +178,53 @@ class ApplicationFormServiceTest {
         assertTrue(contentsCaptor.firstValue.all { it.content == "" })
     }
 
+    @Test
+    fun `assignManager는 담당자 운영진을 가입신청서에 배정한다`() {
+        val managerUserId = 10L
+        val applicationForm =
+            ApplicationForm(
+                id = "form-1",
+                info21Id = "2021999999",
+                submittee = "김테스트",
+                status = ApplicationFormStatus.SUBMITTED,
+            )
+        whenever(memberRepository.findById(managerUserId)).thenReturn(Optional.of(createMember(managerUserId, manager = true)))
+        whenever(applicationFormRepository.findById(applicationForm.id)).thenReturn(Optional.of(applicationForm))
+
+        service.assignManager(applicationForm.id, managerUserId)
+
+        val formCaptor = argumentCaptor<ApplicationForm>()
+        verify(applicationFormRepository).save(formCaptor.capture())
+        assertEquals(applicationForm.id, formCaptor.firstValue.id)
+        assertEquals(managerUserId, formCaptor.firstValue.assignedUserId)
+    }
+
+    @Test
+    fun `assignManager는 담당자 유저가 운영진이 아니면 UnprocessableEntityException을 던진다`() {
+        val managerUserId = 10L
+        whenever(memberRepository.findById(managerUserId)).thenReturn(Optional.of(createMember(managerUserId, manager = false)))
+
+        assertThrows<UnprocessableEntityException> {
+            service.assignManager("form-1", managerUserId)
+        }
+
+        verify(applicationFormRepository, never()).findById(any())
+        verify(applicationFormRepository, never()).save(any())
+    }
+
+    @Test
+    fun `assignManager는 가입신청서가 없으면 NotFoundException을 던진다`() {
+        val managerUserId = 10L
+        whenever(memberRepository.findById(managerUserId)).thenReturn(Optional.of(createMember(managerUserId, manager = true)))
+        whenever(applicationFormRepository.findById("missing-form")).thenReturn(Optional.empty())
+
+        assertThrows<NotFoundException> {
+            service.assignManager("missing-form", managerUserId)
+        }
+
+        verify(applicationFormRepository, never()).save(any())
+    }
+
     private fun stuauthResponse(
         code: Int = 200,
         name: String = "김테스트",
@@ -190,4 +248,26 @@ class ApplicationFormServiceTest {
                 ),
         )
     }
+
+    private fun createMember(
+        userId: Long = 1L,
+        manager: Boolean = false,
+    ): Member =
+        Member(
+            id = userId,
+            name = "testuser",
+            admission = "20",
+            realname = "테스트 사용자",
+            college = "소프트웨어융합학과",
+            grade = 3L,
+            manager = manager,
+            studentStatus = StudentStatus.UNDERGRADUATE,
+            email = "test@example.com",
+            status = UserStatus.ACTIVE,
+            khuisauthAt = Instant.now(),
+            updatedAt = LocalDateTime.now(),
+            createdAt = Instant.now(),
+            lastLogin = Instant.now(),
+            lastEnter = LocalDateTime.now(),
+        )
 }


### PR DESCRIPTION
1. 주어진 `managerUserId` 유저가 운영진인지 확인합니다. 아니라면 422.
2. 주어진 `applicationFormId` 가입신청서 엔티티를 조회합니다. 없다면 404.
3. 조회한 가입신청서의 `assignedUserId`에 `managerUserId`를 넣습니다.
4. 저장합니다.

### Query Parameters

- *(없음)*

### Request Body

- managerUserId: number, required

### Status Code

- 204 No Content

### Response Body

- *(없음)*