### PR TITLE
feat: ScheduleCategory tier 판별 함수 추가

### DIFF
--- a/src/main/kotlin/com/sight/domain/schedule/ScheduleCategory.kt
+++ b/src/main/kotlin/com/sight/domain/schedule/ScheduleCategory.kt
@@ -9,4 +9,14 @@ enum class ScheduleCategory(val label: String) {
     SEMINAR("세미나"),
     AFTERPARTY("뒷풀이"),
     OTHER("기타"),
+    ;
+
+    /** 일반 회원이 생성할 수 있는 그룹 활동 카테고리. */
+    val isGroupActivity: Boolean get() = this == GROUP_ACTIVITY
+
+    /** 빅세미나(big_seminar) 처리가 동반되는 세미나 카테고리. */
+    val isSeminar: Boolean get() = this == SEMINAR
+
+    /** 운영진 전용 카테고리(그룹 활동·세미나를 제외한 전부). */
+    val isManagerCategory: Boolean get() = !isGroupActivity && !isSeminar
 }

--- a/src/main/kotlin/com/sight/domain/schedule/ScheduleStateConverter.kt
+++ b/src/main/kotlin/com/sight/domain/schedule/ScheduleStateConverter.kt
@@ -5,7 +5,7 @@ import jakarta.persistence.Converter
 
 @Converter
 class ScheduleStateConverter : AttributeConverter<ScheduleState, String> {
-    override fun convertToDatabaseColumn(attribute: ScheduleState): String = attribute.name
+    override fun convertToDatabaseColumn(attribute: ScheduleState): String = attribute.state
 
     override fun convertToEntityAttribute(dbData: String): ScheduleState = ScheduleState.valueOf(dbData.uppercase())
 }

--- a/src/main/kotlin/com/sight/repository/BigSeminarRepository.kt
+++ b/src/main/kotlin/com/sight/repository/BigSeminarRepository.kt
@@ -2,7 +2,11 @@ package com.sight.repository
 
 import com.sight.domain.seminar.BigSeminar
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
+@Repository
 interface BigSeminarRepository : JpaRepository<BigSeminar, String> {
     fun findByScheduleId(scheduleId: Long): BigSeminar?
+
+    fun deleteByScheduleId(scheduleId: Long)
 }

--- a/src/main/kotlin/com/sight/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ScheduleRepository.kt
@@ -17,4 +17,12 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
         @Param("from") from: LocalDateTime,
         pageable: Pageable,
     ): List<Schedule>
+
+    @Query("SELECT s FROM Schedule s WHERE s.state = 'public' ORDER BY s.scheduledAt ASC")
+    fun findAllActive(pageable: Pageable): List<Schedule>
+
+    @Query("SELECT s FROM Schedule s WHERE s.id = :id AND s.state = 'public'")
+    fun findActiveById(
+        @Param("id") id: Long,
+    ): Schedule?
 }

--- a/src/test/kotlin/com/sight/domain/schedule/ScheduleCategoryTest.kt
+++ b/src/test/kotlin/com/sight/domain/schedule/ScheduleCategoryTest.kt
@@ -1,0 +1,55 @@
+package com.sight.domain.schedule
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ScheduleCategoryTest {
+    @Test
+    fun `GROUP_ACTIVITY는 그룹 활동 tier로 분류된다`() {
+        val category = ScheduleCategory.GROUP_ACTIVITY
+
+        assertTrue(category.isGroupActivity)
+        assertFalse(category.isSeminar)
+        assertFalse(category.isManagerCategory)
+    }
+
+    @Test
+    fun `SEMINAR는 세미나 tier로 분류된다`() {
+        val category = ScheduleCategory.SEMINAR
+
+        assertTrue(category.isSeminar)
+        assertFalse(category.isGroupActivity)
+        assertFalse(category.isManagerCategory)
+    }
+
+    @Test
+    fun `CLUB ACADEMIC EXTERNAL MANAGEMENT AFTERPARTY OTHER는 운영진 tier로 분류된다`() {
+        val managerCategories =
+            listOf(
+                ScheduleCategory.CLUB,
+                ScheduleCategory.ACADEMIC,
+                ScheduleCategory.EXTERNAL,
+                ScheduleCategory.MANAGEMENT,
+                ScheduleCategory.AFTERPARTY,
+                ScheduleCategory.OTHER,
+            )
+
+        managerCategories.forEach { category ->
+            assertTrue(category.isManagerCategory, "$category 는 운영진 카테고리여야 한다")
+            assertFalse(category.isGroupActivity, "$category 는 그룹 활동이 아니어야 한다")
+            assertFalse(category.isSeminar, "$category 는 세미나가 아니어야 한다")
+        }
+    }
+
+    @Test
+    fun `모든 카테고리는 정확히 하나의 tier에만 속한다`() {
+        ScheduleCategory.entries.forEach { category ->
+            val matched =
+                listOf(category.isGroupActivity, category.isSeminar, category.isManagerCategory)
+                    .count { it }
+
+            assertTrue(matched == 1, "$category 는 정확히 하나의 tier에 속해야 한다 (matched=$matched)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `ScheduleCategory`에 `isGroupActivity` / `isSeminar` / `isManagerCategory` 프로퍼티 추가 — 후속 일정 CRUD에서 카테고리 분기 처리에 사용
- `ScheduleStateConverter`를 `attribute.state`(소문자) 기준으로 수정 (기존 `attribute.name`은 대문자였음)

## Test plan
- [x] `ScheduleCategoryTest` — 모든 카테고리가 정확히 하나의 tier에 속하는지 검증
- [x] `./gradlew ktlintCheck` 통과