### PR TITLE
feat: Schedule/BigSeminar 리포지토리에 일정 CRUD용 메서드 추가

### DIFF
--- a/src/main/kotlin/com/sight/repository/BigSeminarRepository.kt
+++ b/src/main/kotlin/com/sight/repository/BigSeminarRepository.kt
@@ -2,7 +2,11 @@ package com.sight.repository
 
 import com.sight.domain.seminar.BigSeminar
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
+@Repository
 interface BigSeminarRepository : JpaRepository<BigSeminar, String> {
     fun findByScheduleId(scheduleId: Long): BigSeminar?
+
+    fun deleteByScheduleId(scheduleId: Long)
 }

--- a/src/main/kotlin/com/sight/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ScheduleRepository.kt
@@ -17,4 +17,12 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
         @Param("from") from: LocalDateTime,
         pageable: Pageable,
     ): List<Schedule>
+
+    @Query("SELECT s FROM Schedule s WHERE s.state = 'public' ORDER BY s.scheduledAt ASC")
+    fun findAllActive(pageable: Pageable): List<Schedule>
+
+    @Query("SELECT s FROM Schedule s WHERE s.id = :id AND s.state = 'public'")
+    fun findActiveById(
+        @Param("id") id: Long,
+    ): Schedule?
 }


### PR DESCRIPTION
## Summary
- `ScheduleRepository`: `findAllActive`, `findActiveById` 추가 — 일정 목록 조회/단건 조회용
- `BigSeminarRepository`: `@Repository` 어노테이션 + `deleteByScheduleId` 추가 — 카테고리 변경 시 빅세미나 삭제용

## Test plan
- [x] `./gradlew compileKotlin` 통과
- [x] `./gradlew ktlintCheck` 통과

> base는 `feat/schedule-domain` (stacked PR). 이전 PR 머지 후 자동으로 base가 `feat/group-side-features`로 재설정됩니다.