### PR TITLE
feat: 일정 CRUD API 구현 (운영진 카테고리·카테고리 변경)

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ScheduleController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ScheduleController.kt
@@ -65,7 +65,7 @@ class ScheduleController(
     ): CreateScheduleResponse {
         val schedule =
             scheduleService.createSchedule(
-                requester = requester,
+                requesterUserId = requester.userId,
                 title = request.title,
                 category = request.category,
                 location = request.location,
@@ -86,7 +86,6 @@ class ScheduleController(
     ): GetScheduleResponse {
         val schedule =
             scheduleService.updateSchedule(
-                requester = requester,
                 id = scheduleId,
                 title = request.title,
                 location = request.location,
@@ -106,7 +105,6 @@ class ScheduleController(
     ): GetScheduleResponse {
         val (schedule, bigSeminar) =
             scheduleService.updateScheduleCategory(
-                requester = requester,
                 id = scheduleId,
                 category = request.category,
                 isSummerSeason = request.isSummerSeason,
@@ -119,9 +117,8 @@ class ScheduleController(
     @DeleteMapping("/schedules/{scheduleId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteSchedule(
-        requester: Requester,
         @PathVariable scheduleId: Long,
     ) {
-        scheduleService.deleteSchedule(requester, scheduleId)
+        scheduleService.deleteSchedule(scheduleId)
     }
 }

--- a/src/main/kotlin/com/sight/controllers/http/ScheduleController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ScheduleController.kt
@@ -1,13 +1,29 @@
 package com.sight.controllers.http
 
+import com.sight.controllers.http.dto.CreateScheduleRequest
+import com.sight.controllers.http.dto.CreateScheduleResponse
+import com.sight.controllers.http.dto.GetScheduleResponse
 import com.sight.controllers.http.dto.ListSchedulesResponse
+import com.sight.controllers.http.dto.UpdateScheduleCategoryRequest
+import com.sight.controllers.http.dto.UpdateScheduleRequest
+import com.sight.core.auth.Auth
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
 import com.sight.service.ScheduleService
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
 
@@ -21,13 +37,91 @@ class ScheduleController(
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
         from: LocalDateTime?,
-        @RequestParam(defaultValue = "5")
+        @RequestParam(defaultValue = "50")
         @Min(1)
         @Max(50)
         limit: Int,
     ): ListSchedulesResponse {
-        val fromDateTime = from ?: LocalDateTime.now()
-        val schedules = scheduleService.listSchedules(fromDateTime, limit)
+        val schedules = scheduleService.listSchedules(from, limit)
         return ListSchedulesResponse.from(schedules)
+    }
+
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @GetMapping("/schedules/{scheduleId}")
+    fun getSchedule(
+        requester: Requester,
+        @PathVariable scheduleId: Long,
+    ): GetScheduleResponse {
+        val schedule = scheduleService.getScheduleById(scheduleId)
+        return GetScheduleResponse.from(schedule, requester.role)
+    }
+
+    @Auth([UserRole.MANAGER])
+    @PostMapping("/schedules")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createSchedule(
+        requester: Requester,
+        @Valid @RequestBody request: CreateScheduleRequest,
+    ): CreateScheduleResponse {
+        val schedule =
+            scheduleService.createSchedule(
+                requester = requester,
+                title = request.title,
+                category = request.category,
+                location = request.location,
+                scheduledAt = request.scheduledAt,
+                endAt = request.endAt,
+                expoint = request.expoint,
+                generateCheckCode = request.generateCheckCode,
+            )
+        return CreateScheduleResponse.from(schedule)
+    }
+
+    @Auth([UserRole.MANAGER])
+    @PatchMapping("/schedules/{scheduleId}")
+    fun updateSchedule(
+        requester: Requester,
+        @PathVariable scheduleId: Long,
+        @Valid @RequestBody request: UpdateScheduleRequest,
+    ): GetScheduleResponse {
+        val schedule =
+            scheduleService.updateSchedule(
+                requester = requester,
+                id = scheduleId,
+                title = request.title,
+                location = request.location,
+                scheduledAt = request.scheduledAt,
+                endAt = request.endAt,
+                expoint = request.expoint,
+            )
+        return GetScheduleResponse.from(schedule, requester.role)
+    }
+
+    @Auth([UserRole.MANAGER])
+    @PatchMapping("/schedules/{scheduleId}/category")
+    fun updateScheduleCategory(
+        requester: Requester,
+        @PathVariable scheduleId: Long,
+        @Valid @RequestBody request: UpdateScheduleCategoryRequest,
+    ): GetScheduleResponse {
+        val (schedule, bigSeminar) =
+            scheduleService.updateScheduleCategory(
+                requester = requester,
+                id = scheduleId,
+                category = request.category,
+                isSummerSeason = request.isSummerSeason,
+                isSpeakAfter = request.isSpeakAfter,
+            )
+        return GetScheduleResponse.from(schedule, requester.role, bigSeminar)
+    }
+
+    @Auth([UserRole.MANAGER])
+    @DeleteMapping("/schedules/{scheduleId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteSchedule(
+        requester: Requester,
+        @PathVariable scheduleId: Long,
+    ) {
+        scheduleService.deleteSchedule(requester, scheduleId)
     }
 }

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateScheduleRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateScheduleRequest.kt
@@ -1,0 +1,22 @@
+package com.sight.controllers.http.dto
+
+import com.sight.domain.schedule.ScheduleCategory
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PositiveOrZero
+import java.time.LocalDateTime
+
+data class CreateScheduleRequest(
+    @field:NotBlank
+    val title: String,
+    @field:NotNull
+    val category: ScheduleCategory,
+    val location: String?,
+    @field:NotNull
+    val scheduledAt: LocalDateTime,
+    @field:NotNull
+    val endAt: LocalDateTime,
+    @field:PositiveOrZero
+    val expoint: Int = 0,
+    val generateCheckCode: Boolean = false,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateScheduleResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateScheduleResponse.kt
@@ -1,23 +1,12 @@
 package com.sight.controllers.http.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.sight.domain.schedule.Schedule
 import com.sight.domain.schedule.ScheduleCategory
+import com.sight.domain.seminar.BigSeminar
 
-data class ListSchedulesResponse(
-    val count: Int,
-    val schedules: List<ScheduleDto>,
-) {
-    companion object {
-        fun from(schedules: List<Schedule>): ListSchedulesResponse {
-            return ListSchedulesResponse(
-                count = schedules.size,
-                schedules = schedules.map { ScheduleDto.from(it) },
-            )
-        }
-    }
-}
-
-data class ScheduleDto(
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CreateScheduleResponse(
     val id: Long,
     val title: String,
     val category: ScheduleCategory,
@@ -26,11 +15,18 @@ data class ScheduleDto(
     val scheduledAt: String,
     val endAt: String,
     val expoint: Int,
+    val checkCode: String?,
     val author: Long,
+    val createdAt: String,
+    val isSummerSeason: Boolean?,
+    val isSpeakAfter: Boolean?,
 ) {
     companion object {
-        fun from(schedule: Schedule): ScheduleDto {
-            return ScheduleDto(
+        fun from(
+            schedule: Schedule,
+            bigSeminar: BigSeminar? = null,
+        ): CreateScheduleResponse {
+            return CreateScheduleResponse(
                 id = schedule.id,
                 title = schedule.title,
                 category = schedule.category,
@@ -39,7 +35,11 @@ data class ScheduleDto(
                 scheduledAt = schedule.scheduledAt.toString(),
                 endAt = schedule.endAt.toString(),
                 expoint = schedule.expoint,
+                checkCode = schedule.checkCode,
                 author = schedule.author,
+                createdAt = schedule.createdAt.toString(),
+                isSummerSeason = bigSeminar?.isSummerSeason,
+                isSpeakAfter = bigSeminar?.isSpeakAfter,
             )
         }
     }

--- a/src/main/kotlin/com/sight/controllers/http/dto/GetScheduleResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/GetScheduleResponse.kt
@@ -1,0 +1,50 @@
+package com.sight.controllers.http.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.sight.core.auth.UserRole
+import com.sight.domain.schedule.Schedule
+import com.sight.domain.schedule.ScheduleCategory
+import com.sight.domain.seminar.BigSeminar
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class GetScheduleResponse(
+    val id: Long,
+    val title: String,
+    val category: ScheduleCategory,
+    val location: String?,
+    val state: String,
+    val scheduledAt: String,
+    val endAt: String,
+    val expoint: Int,
+    val checkCode: String?,
+    val author: Long,
+    val createdAt: String,
+    val updatedAt: String,
+    val isSummerSeason: Boolean?,
+    val isSpeakAfter: Boolean?,
+) {
+    companion object {
+        fun from(
+            schedule: Schedule,
+            role: UserRole,
+            bigSeminar: BigSeminar? = null,
+        ): GetScheduleResponse {
+            return GetScheduleResponse(
+                id = schedule.id,
+                title = schedule.title,
+                category = schedule.category,
+                location = schedule.location,
+                state = schedule.state.state,
+                scheduledAt = schedule.scheduledAt.toString(),
+                endAt = schedule.endAt.toString(),
+                expoint = schedule.expoint,
+                checkCode = if (role == UserRole.MANAGER) schedule.checkCode else null,
+                author = schedule.author,
+                createdAt = schedule.createdAt.toString(),
+                updatedAt = schedule.updatedAt.toString(),
+                isSummerSeason = bigSeminar?.isSummerSeason,
+                isSpeakAfter = bigSeminar?.isSpeakAfter,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/dto/UpdateScheduleCategoryRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/UpdateScheduleCategoryRequest.kt
@@ -1,0 +1,11 @@
+package com.sight.controllers.http.dto
+
+import com.sight.domain.schedule.ScheduleCategory
+import jakarta.validation.constraints.NotNull
+
+data class UpdateScheduleCategoryRequest(
+    @field:NotNull
+    val category: ScheduleCategory,
+    val isSummerSeason: Boolean?,
+    val isSpeakAfter: Boolean?,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/UpdateScheduleRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/UpdateScheduleRequest.kt
@@ -1,0 +1,18 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PositiveOrZero
+import java.time.LocalDateTime
+
+data class UpdateScheduleRequest(
+    @field:NotBlank
+    val title: String,
+    val location: String?,
+    @field:NotNull
+    val scheduledAt: LocalDateTime,
+    @field:NotNull
+    val endAt: LocalDateTime,
+    @field:PositiveOrZero
+    val expoint: Int,
+)

--- a/src/main/kotlin/com/sight/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ScheduleRepository.kt
@@ -3,6 +3,7 @@ package com.sight.repository
 import com.sight.domain.schedule.Schedule
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -25,4 +26,10 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
     fun findActiveById(
         @Param("id") id: Long,
     ): Schedule?
+
+    @Modifying
+    @Query("UPDATE Schedule s SET s.state = 'trash', s.updatedAt = CURRENT_TIMESTAMP WHERE s.id = :id AND s.state = 'public'")
+    fun deleteActiveById(
+        @Param("id") id: Long,
+    )
 }

--- a/src/main/kotlin/com/sight/service/ScheduleService.kt
+++ b/src/main/kotlin/com/sight/service/ScheduleService.kt
@@ -1,6 +1,5 @@
 package com.sight.service
 
-import com.sight.core.auth.Requester
 import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.NotFoundException
 import com.sight.domain.schedule.Schedule
@@ -43,7 +42,7 @@ class ScheduleService(
 
     @Transactional
     fun createSchedule(
-        requester: Requester,
+        requesterUserId: Long,
         title: String,
         category: ScheduleCategory,
         location: String?,
@@ -55,12 +54,11 @@ class ScheduleService(
         if (!category.isManagerCategory) {
             throw BadRequestException("그룹 활동·세미나 일정은 전용 엔드포인트를 사용해 주세요.")
         }
-        return saveNewSchedule(requester, title, category, location, scheduledAt, endAt, expoint, generateCheckCode)
+        return saveNewSchedule(requesterUserId, title, category, location, scheduledAt, endAt, expoint, generateCheckCode)
     }
 
     @Transactional
     fun updateSchedule(
-        requester: Requester,
         id: Long,
         title: String,
         location: String?,
@@ -74,7 +72,6 @@ class ScheduleService(
 
     @Transactional
     fun updateScheduleCategory(
-        requester: Requester,
         id: Long,
         category: ScheduleCategory,
         isSummerSeason: Boolean?,
@@ -106,10 +103,7 @@ class ScheduleService(
     }
 
     @Transactional
-    fun deleteSchedule(
-        requester: Requester,
-        id: Long,
-    ) {
+    fun deleteSchedule(id: Long) {
         val existing = findActiveScheduleInTier(id) { it.isManagerCategory }
         softDeleteSchedule(existing)
     }
@@ -117,7 +111,7 @@ class ScheduleService(
     // ===== 공통 helper =====
 
     private fun saveNewSchedule(
-        requester: Requester,
+        requesterUserId: Long,
         title: String,
         category: ScheduleCategory,
         location: String?,
@@ -132,7 +126,7 @@ class ScheduleService(
                 id = pickAvailableScheduleId(),
                 category = category,
                 title = title,
-                author = requester.userId,
+                author = requesterUserId,
                 state = ScheduleState.PUBLIC,
                 scheduledAt = scheduledAt,
                 endAt = endAt,

--- a/src/main/kotlin/com/sight/service/ScheduleService.kt
+++ b/src/main/kotlin/com/sight/service/ScheduleService.kt
@@ -105,7 +105,7 @@ class ScheduleService(
     @Transactional
     fun deleteSchedule(id: Long) {
         val existing = findActiveScheduleInTier(id) { it.isManagerCategory }
-        softDeleteSchedule(existing)
+        scheduleRepository.deleteActiveById(existing.id)
     }
 
     // ===== 공통 helper =====
@@ -156,10 +156,6 @@ class ScheduleService(
                 updatedAt = LocalDateTime.now(),
             ),
         )
-    }
-
-    private fun softDeleteSchedule(existing: Schedule) {
-        scheduleRepository.save(existing.copy(state = ScheduleState.TRASH, updatedAt = LocalDateTime.now()))
     }
 
     private fun upsertBigSeminar(

--- a/src/main/kotlin/com/sight/service/ScheduleService.kt
+++ b/src/main/kotlin/com/sight/service/ScheduleService.kt
@@ -1,22 +1,235 @@
 package com.sight.service
 
+import com.sight.core.auth.Requester
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.NotFoundException
 import com.sight.domain.schedule.Schedule
+import com.sight.domain.schedule.ScheduleCategory
+import com.sight.domain.schedule.ScheduleState
+import com.sight.domain.seminar.BigSeminar
+import com.sight.repository.BigSeminarRepository
 import com.sight.repository.ScheduleRepository
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.Month
+import java.time.ZoneId
+import kotlin.random.Random
 
 @Service
 class ScheduleService(
     private val scheduleRepository: ScheduleRepository,
+    private val bigSeminarRepository: BigSeminarRepository,
 ) {
     @Transactional(readOnly = true)
     fun listSchedules(
-        from: LocalDateTime,
+        from: LocalDateTime?,
         limit: Int,
     ): List<Schedule> {
         val pageable = PageRequest.of(0, limit)
-        return scheduleRepository.findUpcoming(from, pageable)
+        return if (from != null) {
+            scheduleRepository.findUpcoming(from, pageable)
+        } else {
+            scheduleRepository.findAllActive(pageable)
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun getScheduleById(id: Long): Schedule {
+        return scheduleRepository.findActiveById(id)
+            ?: throw NotFoundException("존재하지 않는 일정입니다.")
+    }
+
+    @Transactional
+    fun createSchedule(
+        requester: Requester,
+        title: String,
+        category: ScheduleCategory,
+        location: String?,
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+        expoint: Int,
+        generateCheckCode: Boolean,
+    ): Schedule {
+        if (!category.isManagerCategory) {
+            throw BadRequestException("그룹 활동·세미나 일정은 전용 엔드포인트를 사용해 주세요.")
+        }
+        return saveNewSchedule(requester, title, category, location, scheduledAt, endAt, expoint, generateCheckCode)
+    }
+
+    @Transactional
+    fun updateSchedule(
+        requester: Requester,
+        id: Long,
+        title: String,
+        location: String?,
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+        expoint: Int,
+    ): Schedule {
+        val existing = findActiveScheduleInTier(id) { it.isManagerCategory }
+        return applyScheduleUpdate(existing, title, location, scheduledAt, endAt, expoint)
+    }
+
+    @Transactional
+    fun updateScheduleCategory(
+        requester: Requester,
+        id: Long,
+        category: ScheduleCategory,
+        isSummerSeason: Boolean?,
+        isSpeakAfter: Boolean?,
+    ): Pair<Schedule, BigSeminar?> {
+        if (category.isGroupActivity) {
+            throw BadRequestException("그룹 활동 카테고리로는 변경할 수 없습니다.")
+        }
+        val existing =
+            scheduleRepository.findActiveById(id)
+                ?: throw NotFoundException("존재하지 않는 일정입니다.")
+
+        val updated = scheduleRepository.save(existing.copy(category = category, updatedAt = LocalDateTime.now()))
+
+        val bigSeminar =
+            when {
+                category.isSeminar -> {
+                    val summer = isSummerSeason ?: throw BadRequestException("세미나로 변경하려면 isSummerSeason이 필요합니다.")
+                    val speakAfter = isSpeakAfter ?: throw BadRequestException("세미나로 변경하려면 isSpeakAfter가 필요합니다.")
+                    upsertBigSeminar(updated.id, summer, speakAfter)
+                }
+                existing.category.isSeminar -> {
+                    bigSeminarRepository.deleteByScheduleId(updated.id)
+                    null
+                }
+                else -> null
+            }
+        return updated to bigSeminar
+    }
+
+    @Transactional
+    fun deleteSchedule(
+        requester: Requester,
+        id: Long,
+    ) {
+        val existing = findActiveScheduleInTier(id) { it.isManagerCategory }
+        softDeleteSchedule(existing)
+    }
+
+    // ===== 공통 helper =====
+
+    private fun saveNewSchedule(
+        requester: Requester,
+        title: String,
+        category: ScheduleCategory,
+        location: String?,
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+        expoint: Int,
+        generateCheckCode: Boolean,
+    ): Schedule {
+        validateTimeRange(scheduledAt, endAt)
+        val schedule =
+            Schedule(
+                id = pickAvailableScheduleId(),
+                category = category,
+                title = title,
+                author = requester.userId,
+                state = ScheduleState.PUBLIC,
+                scheduledAt = scheduledAt,
+                endAt = endAt,
+                location = location,
+                expoint = expoint,
+                checkCode = if (generateCheckCode) createCheckCode() else null,
+            )
+        return scheduleRepository.save(schedule)
+    }
+
+    private fun applyScheduleUpdate(
+        existing: Schedule,
+        title: String,
+        location: String?,
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+        expoint: Int,
+    ): Schedule {
+        validateTimeRange(scheduledAt, endAt)
+        return scheduleRepository.save(
+            existing.copy(
+                title = title,
+                location = location,
+                scheduledAt = scheduledAt,
+                endAt = endAt,
+                expoint = expoint,
+                updatedAt = LocalDateTime.now(),
+            ),
+        )
+    }
+
+    private fun softDeleteSchedule(existing: Schedule) {
+        scheduleRepository.save(existing.copy(state = ScheduleState.TRASH, updatedAt = LocalDateTime.now()))
+    }
+
+    private fun upsertBigSeminar(
+        scheduleId: Long,
+        isSummerSeason: Boolean,
+        isSpeakAfter: Boolean,
+    ): BigSeminar {
+        val existing = bigSeminarRepository.findByScheduleId(scheduleId)
+        val entity =
+            existing?.copy(isSummerSeason = isSummerSeason, isSpeakAfter = isSpeakAfter)
+                ?: BigSeminar(
+                    id = scheduleId.toString(),
+                    scheduleId = scheduleId,
+                    isSummerSeason = isSummerSeason,
+                    isSpeakAfter = isSpeakAfter,
+                )
+        return bigSeminarRepository.save(entity)
+    }
+
+    private fun findActiveScheduleInTier(
+        id: Long,
+        inTier: (ScheduleCategory) -> Boolean,
+    ): Schedule {
+        val existing =
+            scheduleRepository.findActiveById(id)
+                ?: throw NotFoundException("존재하지 않는 일정입니다.")
+        if (!inTier(existing.category)) {
+            throw BadRequestException("이 엔드포인트로 처리할 수 없는 카테고리의 일정입니다.")
+        }
+        return existing
+    }
+
+    private fun validateTimeRange(
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+    ) {
+        if (!endAt.isAfter(scheduledAt)) {
+            throw BadRequestException("종료 시각은 시작 시각 이후여야 합니다.")
+        }
+    }
+
+    private fun createCheckCode(): String = "%04d".format(Random.nextInt(10000))
+
+    private fun pickAvailableScheduleId(): Long {
+        repeat(MAX_SCHEDULE_ID_RETRY + 1) {
+            val id = createNewScheduleId()
+            if (!scheduleRepository.existsById(id)) return id
+        }
+        throw IllegalStateException("schedule ID 채번 $MAX_SCHEDULE_ID_RETRY 회 retry 후에도 충돌")
+    }
+
+    private fun createNewScheduleId(): Long {
+        val minimumId = 1_000_000
+        val millisUntil20250101 =
+            LocalDateTime.of(2025, Month.JANUARY, 1, 0, 0, 0)
+                .atZone(KST).toInstant().toEpochMilli()
+        val currentTimestamp = System.currentTimeMillis()
+        val timePart = (currentTimestamp - millisUntil20250101) / 1000 / 60
+        val randomPart = Random.nextLong(0L, 1000L)
+        return minimumId + timePart * 1000 + randomPart
+    }
+
+    companion object {
+        private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+        private const val MAX_SCHEDULE_ID_RETRY = 3
     }
 }

--- a/src/test/kotlin/com/sight/controllers/http/ScheduleControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/ScheduleControllerTest.kt
@@ -1,0 +1,86 @@
+package com.sight.controllers.http
+
+import com.sight.domain.schedule.Schedule
+import com.sight.domain.schedule.ScheduleCategory
+import com.sight.domain.schedule.ScheduleState
+import com.sight.service.ScheduleService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+@WebMvcTest(ScheduleController::class, excludeAutoConfiguration = [SecurityAutoConfiguration::class])
+class ScheduleControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var scheduleService: ScheduleService
+
+    @Test
+    fun `일정 목록 조회 응답에 신규 컬럼이 포함된다`() {
+        val schedule =
+            Schedule(
+                id = 1L,
+                category = ScheduleCategory.CLUB,
+                title = "동아리 정기 모임",
+                author = 10L,
+                state = ScheduleState.PUBLIC,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                location = "khlug_406",
+                expoint = 10,
+                checkCode = "1234",
+            )
+        given(scheduleService.listSchedules(anyOrNull(), any())).willReturn(listOf(schedule))
+
+        mockMvc.perform(get("/schedules"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.count").value(1))
+            .andExpect(jsonPath("$.schedules[0].id").value(1))
+            .andExpect(jsonPath("$.schedules[0].title").value("동아리 정기 모임"))
+            .andExpect(jsonPath("$.schedules[0].location").value("khlug_406"))
+            .andExpect(jsonPath("$.schedules[0].expoint").value(10))
+            .andExpect(jsonPath("$.schedules[0].author").value(10))
+            .andExpect(jsonPath("$.schedules[0].scheduledAt").exists())
+            .andExpect(jsonPath("$.schedules[0].endAt").exists())
+            .andExpect(jsonPath("$.schedules[0].state").value("public"))
+    }
+
+    @Test
+    fun `일정 목록 응답에는 checkCode 필드가 포함되지 않는다`() {
+        val schedule =
+            Schedule(
+                id = 1L,
+                category = ScheduleCategory.CLUB,
+                title = "test",
+                author = 10L,
+                state = ScheduleState.PUBLIC,
+                scheduledAt = LocalDateTime.now(),
+                endAt = LocalDateTime.now().plusHours(1),
+                checkCode = "1234",
+            )
+        given(scheduleService.listSchedules(anyOrNull(), any())).willReturn(listOf(schedule))
+
+        mockMvc.perform(get("/schedules"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.schedules[0].checkCode").doesNotExist())
+    }
+
+    @Test
+    fun `인증 없이도 일정 목록을 조회할 수 있다`() {
+        given(scheduleService.listSchedules(anyOrNull(), any())).willReturn(emptyList())
+
+        mockMvc.perform(get("/schedules"))
+            .andExpect(status().isOk)
+    }
+}

--- a/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -327,16 +326,13 @@ class ScheduleServiceTest {
     }
 
     @Test
-    fun `deleteSchedule은 운영진 일정 state를 TRASH로 전환한다`() {
+    fun `deleteSchedule은 운영진 일정을 삭제한다`() {
         val existing = scheduleOf(category = ScheduleCategory.CLUB)
         given(scheduleRepository.findActiveById(1L)).willReturn(existing)
-        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
 
         scheduleService.deleteSchedule(1L)
 
-        val captor = argumentCaptor<Schedule>()
-        verify(scheduleRepository).save(captor.capture())
-        assertEquals(ScheduleState.TRASH, captor.firstValue.state)
+        verify(scheduleRepository).deleteActiveById(1L)
     }
 
     @Test

--- a/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
@@ -1,7 +1,5 @@
 package com.sight.service
 
-import com.sight.core.auth.Requester
-import com.sight.core.auth.UserRole
 import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.NotFoundException
 import com.sight.domain.schedule.Schedule
@@ -129,12 +127,11 @@ class ScheduleServiceTest {
 
     @Test
     fun `createSchedule은 generateCheckCode가 false면 checkCode를 null로 저장한다`() {
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
         given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
 
         val result =
             scheduleService.createSchedule(
-                requester = requester,
+                requesterUserId = 1L,
                 title = "test",
                 category = ScheduleCategory.CLUB,
                 location = "khlug_406",
@@ -153,12 +150,11 @@ class ScheduleServiceTest {
 
     @Test
     fun `createSchedule은 generateCheckCode가 true면 4자리 숫자 checkCode를 생성한다`() {
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
         given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
 
         val result =
             scheduleService.createSchedule(
-                requester = requester,
+                requesterUserId = 1L,
                 title = "test",
                 category = ScheduleCategory.CLUB,
                 location = null,
@@ -175,12 +171,10 @@ class ScheduleServiceTest {
 
     @Test
     fun `createSchedule은 운영진 카테고리가 아니면 BadRequestException 던진다`() {
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
-
         listOf(ScheduleCategory.GROUP_ACTIVITY, ScheduleCategory.SEMINAR).forEach { category ->
             assertThrows<BadRequestException> {
                 scheduleService.createSchedule(
-                    requester = requester,
+                    requesterUserId = 1L,
                     title = "test",
                     category = category,
                     location = null,
@@ -195,11 +189,9 @@ class ScheduleServiceTest {
 
     @Test
     fun `createSchedule은 endAt이 scheduledAt 이후가 아니면 BadRequestException 던진다`() {
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
-
         assertThrows<BadRequestException> {
             scheduleService.createSchedule(
-                requester = requester,
+                requesterUserId = 1L,
                 title = "test",
                 category = ScheduleCategory.CLUB,
                 location = null,
@@ -216,11 +208,9 @@ class ScheduleServiceTest {
         val existing = scheduleOf(category = ScheduleCategory.CLUB, checkCode = "1234")
         given(scheduleRepository.findActiveById(1L)).willReturn(existing)
         given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
-        val requester = Requester(userId = 99L, role = UserRole.MANAGER)
 
         val result =
             scheduleService.updateSchedule(
-                requester = requester,
                 id = 1L,
                 title = "new",
                 location = "khlug_406",
@@ -239,11 +229,9 @@ class ScheduleServiceTest {
     fun `updateSchedule은 대상이 운영진 카테고리가 아니면 BadRequestException 던진다`() {
         val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY)
         given(scheduleRepository.findActiveById(1L)).willReturn(existing)
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
 
         assertThrows<BadRequestException> {
             scheduleService.updateSchedule(
-                requester = requester,
                 id = 1L,
                 title = "x",
                 location = null,
@@ -257,11 +245,9 @@ class ScheduleServiceTest {
     @Test
     fun `updateSchedule은 없는 일정에 NotFoundException 던진다`() {
         given(scheduleRepository.findActiveById(999L)).willReturn(null)
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
 
         assertThrows<NotFoundException> {
             scheduleService.updateSchedule(
-                requester = requester,
                 id = 999L,
                 title = "x",
                 location = null,
@@ -279,11 +265,9 @@ class ScheduleServiceTest {
         given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
         given(bigSeminarRepository.findByScheduleId(1L)).willReturn(null)
         given(bigSeminarRepository.save(any<BigSeminar>())).willAnswer { it.arguments[0] as BigSeminar }
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
 
         val (schedule, bigSeminar) =
             scheduleService.updateScheduleCategory(
-                requester = requester,
                 id = 1L,
                 category = ScheduleCategory.SEMINAR,
                 isSummerSeason = true,
@@ -300,11 +284,9 @@ class ScheduleServiceTest {
         val existing = scheduleOf(category = ScheduleCategory.CLUB)
         given(scheduleRepository.findActiveById(1L)).willReturn(existing)
         given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
 
         assertThrows<BadRequestException> {
             scheduleService.updateScheduleCategory(
-                requester = requester,
                 id = 1L,
                 category = ScheduleCategory.SEMINAR,
                 isSummerSeason = null,
@@ -318,11 +300,9 @@ class ScheduleServiceTest {
         val existing = scheduleOf(category = ScheduleCategory.SEMINAR)
         given(scheduleRepository.findActiveById(1L)).willReturn(existing)
         given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
 
         val (schedule, bigSeminar) =
             scheduleService.updateScheduleCategory(
-                requester = requester,
                 id = 1L,
                 category = ScheduleCategory.CLUB,
                 isSummerSeason = null,
@@ -336,11 +316,8 @@ class ScheduleServiceTest {
 
     @Test
     fun `updateScheduleCategory는 GROUP_ACTIVITY로 변경 시 BadRequestException 던진다`() {
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
-
         assertThrows<BadRequestException> {
             scheduleService.updateScheduleCategory(
-                requester = requester,
                 id = 1L,
                 category = ScheduleCategory.GROUP_ACTIVITY,
                 isSummerSeason = null,
@@ -354,9 +331,8 @@ class ScheduleServiceTest {
         val existing = scheduleOf(category = ScheduleCategory.CLUB)
         given(scheduleRepository.findActiveById(1L)).willReturn(existing)
         given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
-        val requester = Requester(userId = 99L, role = UserRole.MANAGER)
 
-        scheduleService.deleteSchedule(requester, 1L)
+        scheduleService.deleteSchedule(1L)
 
         val captor = argumentCaptor<Schedule>()
         verify(scheduleRepository).save(captor.capture())
@@ -367,20 +343,18 @@ class ScheduleServiceTest {
     fun `deleteSchedule은 대상이 운영진 카테고리가 아니면 BadRequestException 던진다`() {
         val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY)
         given(scheduleRepository.findActiveById(1L)).willReturn(existing)
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
 
         assertThrows<BadRequestException> {
-            scheduleService.deleteSchedule(requester, 1L)
+            scheduleService.deleteSchedule(1L)
         }
     }
 
     @Test
     fun `deleteSchedule은 없는 일정에 NotFoundException 던진다`() {
         given(scheduleRepository.findActiveById(999L)).willReturn(null)
-        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
 
         assertThrows<NotFoundException> {
-            scheduleService.deleteSchedule(requester, 999L)
+            scheduleService.deleteSchedule(999L)
         }
     }
 

--- a/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
@@ -1,33 +1,46 @@
 package com.sight.service
 
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.NotFoundException
 import com.sight.domain.schedule.Schedule
 import com.sight.domain.schedule.ScheduleCategory
 import com.sight.domain.schedule.ScheduleState
+import com.sight.domain.seminar.BigSeminar
+import com.sight.repository.BigSeminarRepository
 import com.sight.repository.ScheduleRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ScheduleServiceTest {
     private val scheduleRepository: ScheduleRepository = mock()
+    private val bigSeminarRepository: BigSeminarRepository = mock()
     private lateinit var scheduleService: ScheduleService
 
     @BeforeEach
     fun setUp() {
-        scheduleService = ScheduleService(scheduleRepository)
+        scheduleService =
+            ScheduleService(
+                scheduleRepository = scheduleRepository,
+                bigSeminarRepository = bigSeminarRepository,
+            )
     }
 
     @Test
     fun `listSchedules는 지정된 시간 이후의 일정 목록을 반환한다`() {
-        // given
         val from = LocalDateTime.of(2024, 1, 1, 0, 0)
-        val limit = 5
         val schedules =
             listOf(
                 Schedule(
@@ -49,12 +62,10 @@ class ScheduleServiceTest {
                     endAt = LocalDateTime.of(2024, 1, 3, 20, 0),
                 ),
             )
-        whenever(scheduleRepository.findUpcoming(any(), any())).thenReturn(schedules)
+        given(scheduleRepository.findUpcoming(any(), any())).willReturn(schedules)
 
-        // when
-        val result = scheduleService.listSchedules(from, limit)
+        val result = scheduleService.listSchedules(from, 5)
 
-        // then
         assertEquals(2, result.size)
         assertEquals("동아리 정기 모임", result[0].title)
         assertEquals("세미나", result[1].title)
@@ -62,52 +73,332 @@ class ScheduleServiceTest {
     }
 
     @Test
+    fun `listSchedules는 from이 null이면 findAllActive를 호출한다`() {
+        given(scheduleRepository.findAllActive(any())).willReturn(emptyList())
+
+        scheduleService.listSchedules(null, 50)
+
+        verify(scheduleRepository).findAllActive(any())
+    }
+
+    @Test
     fun `listSchedules는 일정이 없을 때 빈 목록을 반환한다`() {
-        // given
         val from = LocalDateTime.of(2024, 1, 1, 0, 0)
-        val limit = 5
-        whenever(scheduleRepository.findUpcoming(any(), any())).thenReturn(emptyList())
+        given(scheduleRepository.findUpcoming(any(), any())).willReturn(emptyList())
 
-        // when
-        val result = scheduleService.listSchedules(from, limit)
+        val result = scheduleService.listSchedules(from, 5)
 
-        // then
         assertTrue(result.isEmpty())
         verify(scheduleRepository).findUpcoming(any(), any())
     }
 
     @Test
     fun `listSchedules는 limit 개수만큼 일정을 반환한다`() {
-        // given
         val from = LocalDateTime.of(2024, 1, 1, 0, 0)
-        val limit = 2
         val schedules =
             listOf(
-                Schedule(
-                    id = 1L,
-                    category = ScheduleCategory.CLUB,
-                    title = "일정1",
-                    author = 1L,
-                    state = ScheduleState.PUBLIC,
-                    scheduledAt = LocalDateTime.of(2024, 1, 2, 14, 0),
-                    endAt = LocalDateTime.of(2024, 1, 2, 16, 0),
-                ),
-                Schedule(
-                    id = 2L,
-                    category = ScheduleCategory.ACADEMIC,
-                    title = "일정2",
-                    author = 1L,
-                    state = ScheduleState.PUBLIC,
-                    scheduledAt = LocalDateTime.of(2024, 1, 3, 14, 0),
-                    endAt = LocalDateTime.of(2024, 1, 3, 16, 0),
-                ),
+                scheduleOf(id = 1L),
+                scheduleOf(id = 2L, category = ScheduleCategory.ACADEMIC),
             )
-        whenever(scheduleRepository.findUpcoming(any(), any())).thenReturn(schedules)
+        given(scheduleRepository.findUpcoming(any(), any())).willReturn(schedules)
 
-        // when
-        val result = scheduleService.listSchedules(from, limit)
+        val result = scheduleService.listSchedules(from, 2)
 
-        // then
         assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `getScheduleById는 존재하는 일정을 반환한다`() {
+        val schedule = scheduleOf(id = 1L, category = ScheduleCategory.CLUB)
+        given(scheduleRepository.findActiveById(1L)).willReturn(schedule)
+
+        val result = scheduleService.getScheduleById(1L)
+
+        assertEquals(1L, result.id)
+        verify(scheduleRepository).findActiveById(1L)
+    }
+
+    @Test
+    fun `getScheduleById는 존재하지 않는 일정에 NotFoundException을 던진다`() {
+        given(scheduleRepository.findActiveById(999L)).willReturn(null)
+
+        assertThrows<NotFoundException> {
+            scheduleService.getScheduleById(999L)
+        }
+    }
+
+    @Test
+    fun `createSchedule은 generateCheckCode가 false면 checkCode를 null로 저장한다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+
+        val result =
+            scheduleService.createSchedule(
+                requester = requester,
+                title = "test",
+                category = ScheduleCategory.CLUB,
+                location = "khlug_406",
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 10,
+                generateCheckCode = false,
+            )
+
+        assertEquals(ScheduleCategory.CLUB, result.category)
+        assertEquals(1L, result.author)
+        assertEquals("khlug_406", result.location)
+        assertNull(result.checkCode)
+        verify(scheduleRepository).save(any<Schedule>())
+    }
+
+    @Test
+    fun `createSchedule은 generateCheckCode가 true면 4자리 숫자 checkCode를 생성한다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+
+        val result =
+            scheduleService.createSchedule(
+                requester = requester,
+                title = "test",
+                category = ScheduleCategory.CLUB,
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 0,
+                generateCheckCode = true,
+            )
+
+        val checkCode = result.checkCode
+        assertNotNull(checkCode)
+        assertTrue(checkCode.matches(Regex("^\\d{4}$")))
+    }
+
+    @Test
+    fun `createSchedule은 운영진 카테고리가 아니면 BadRequestException 던진다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        listOf(ScheduleCategory.GROUP_ACTIVITY, ScheduleCategory.SEMINAR).forEach { category ->
+            assertThrows<BadRequestException> {
+                scheduleService.createSchedule(
+                    requester = requester,
+                    title = "test",
+                    category = category,
+                    location = null,
+                    scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                    endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                    expoint = 0,
+                    generateCheckCode = false,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `createSchedule은 endAt이 scheduledAt 이후가 아니면 BadRequestException 던진다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        assertThrows<BadRequestException> {
+            scheduleService.createSchedule(
+                requester = requester,
+                title = "test",
+                category = ScheduleCategory.CLUB,
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                expoint = 0,
+                generateCheckCode = false,
+            )
+        }
+    }
+
+    @Test
+    fun `updateSchedule은 운영진 카테고리 일정을 수정하며 카테고리는 유지된다`() {
+        val existing = scheduleOf(category = ScheduleCategory.CLUB, checkCode = "1234")
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        val requester = Requester(userId = 99L, role = UserRole.MANAGER)
+
+        val result =
+            scheduleService.updateSchedule(
+                requester = requester,
+                id = 1L,
+                title = "new",
+                location = "khlug_406",
+                scheduledAt = LocalDateTime.of(2026, 5, 20, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 20, 16, 0),
+                expoint = 5,
+            )
+
+        assertEquals("new", result.title)
+        assertEquals(ScheduleCategory.CLUB, result.category)
+        assertEquals("1234", result.checkCode)
+        assertEquals(5, result.expoint)
+    }
+
+    @Test
+    fun `updateSchedule은 대상이 운영진 카테고리가 아니면 BadRequestException 던진다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        assertThrows<BadRequestException> {
+            scheduleService.updateSchedule(
+                requester = requester,
+                id = 1L,
+                title = "x",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `updateSchedule은 없는 일정에 NotFoundException 던진다`() {
+        given(scheduleRepository.findActiveById(999L)).willReturn(null)
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        assertThrows<NotFoundException> {
+            scheduleService.updateSchedule(
+                requester = requester,
+                id = 999L,
+                title = "x",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `updateScheduleCategory는 SEMINAR로 변경 시 빅세미나 레코드를 생성한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.CLUB)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        given(bigSeminarRepository.findByScheduleId(1L)).willReturn(null)
+        given(bigSeminarRepository.save(any<BigSeminar>())).willAnswer { it.arguments[0] as BigSeminar }
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        val (schedule, bigSeminar) =
+            scheduleService.updateScheduleCategory(
+                requester = requester,
+                id = 1L,
+                category = ScheduleCategory.SEMINAR,
+                isSummerSeason = true,
+                isSpeakAfter = false,
+            )
+
+        assertEquals(ScheduleCategory.SEMINAR, schedule.category)
+        assertNotNull(bigSeminar)
+        verify(bigSeminarRepository).save(any<BigSeminar>())
+    }
+
+    @Test
+    fun `updateScheduleCategory는 SEMINAR로 변경하는데 빅세미나 필드가 없으면 BadRequestException 던진다`() {
+        val existing = scheduleOf(category = ScheduleCategory.CLUB)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        assertThrows<BadRequestException> {
+            scheduleService.updateScheduleCategory(
+                requester = requester,
+                id = 1L,
+                category = ScheduleCategory.SEMINAR,
+                isSummerSeason = null,
+                isSpeakAfter = null,
+            )
+        }
+    }
+
+    @Test
+    fun `updateScheduleCategory는 SEMINAR에서 다른 카테고리로 변경 시 빅세미나 레코드를 삭제한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.SEMINAR)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        val (schedule, bigSeminar) =
+            scheduleService.updateScheduleCategory(
+                requester = requester,
+                id = 1L,
+                category = ScheduleCategory.CLUB,
+                isSummerSeason = null,
+                isSpeakAfter = null,
+            )
+
+        assertEquals(ScheduleCategory.CLUB, schedule.category)
+        assertNull(bigSeminar)
+        verify(bigSeminarRepository).deleteByScheduleId(1L)
+    }
+
+    @Test
+    fun `updateScheduleCategory는 GROUP_ACTIVITY로 변경 시 BadRequestException 던진다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        assertThrows<BadRequestException> {
+            scheduleService.updateScheduleCategory(
+                requester = requester,
+                id = 1L,
+                category = ScheduleCategory.GROUP_ACTIVITY,
+                isSummerSeason = null,
+                isSpeakAfter = null,
+            )
+        }
+    }
+
+    @Test
+    fun `deleteSchedule은 운영진 일정 state를 TRASH로 전환한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.CLUB)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        val requester = Requester(userId = 99L, role = UserRole.MANAGER)
+
+        scheduleService.deleteSchedule(requester, 1L)
+
+        val captor = argumentCaptor<Schedule>()
+        verify(scheduleRepository).save(captor.capture())
+        assertEquals(ScheduleState.TRASH, captor.firstValue.state)
+    }
+
+    @Test
+    fun `deleteSchedule은 대상이 운영진 카테고리가 아니면 BadRequestException 던진다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        assertThrows<BadRequestException> {
+            scheduleService.deleteSchedule(requester, 1L)
+        }
+    }
+
+    @Test
+    fun `deleteSchedule은 없는 일정에 NotFoundException 던진다`() {
+        given(scheduleRepository.findActiveById(999L)).willReturn(null)
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        assertThrows<NotFoundException> {
+            scheduleService.deleteSchedule(requester, 999L)
+        }
+    }
+
+    private fun scheduleOf(
+        id: Long = 1L,
+        category: ScheduleCategory = ScheduleCategory.CLUB,
+        author: Long = 10L,
+        checkCode: String? = null,
+    ): Schedule {
+        return Schedule(
+            id = id,
+            category = category,
+            title = "일정",
+            author = author,
+            state = ScheduleState.PUBLIC,
+            scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+            endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+            checkCode = checkCode,
+        )
     }
 }


### PR DESCRIPTION
## Summary
- 단건 조회/생성/수정/삭제 엔드포인트 추가 (운영진 전용 카테고리 한정)
  - `GET /schedules/{id}`, `POST /schedules`, `PATCH /schedules/{id}`, `DELETE /schedules/{id}`
- `PATCH /schedules/{id}/category` 추가 — 세미나 전환 시 빅세미나 upsert, 세미나 해제 시 삭제
- 일정 목록 응답 DTO를 신규 도메인(location/expoint/state/endAt 등) 기준으로 정비
- 목록 조회 시 `from` 미지정이면 `findAllActive` 사용, 기본 `limit` 50으로 상향

## Test plan
- [x] `ScheduleServiceTest`: list/get/create/update/updateCategory/delete 케이스 추가 (성공·실패)
- [x] `ScheduleControllerTest`: 신규 응답 컬럼·checkCode 노출 정책 검증
- [x] `./gradlew ktlintCheck` 통과

> base는 `feat/schedule-repository` (stacked PR).