### PR TITLE
feat: 일정 CRUD를 카테고리별 엔드포인트로 분리 (그룹활동·빅세미나)

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/BigSeminarScheduleController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/BigSeminarScheduleController.kt
@@ -1,0 +1,78 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.CreateBigSeminarScheduleRequest
+import com.sight.controllers.http.dto.CreateScheduleResponse
+import com.sight.controllers.http.dto.GetScheduleResponse
+import com.sight.controllers.http.dto.UpdateBigSeminarScheduleRequest
+import com.sight.core.auth.Auth
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
+import com.sight.service.ScheduleService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class BigSeminarScheduleController(
+    private val scheduleService: ScheduleService,
+) {
+    @Auth([UserRole.MANAGER])
+    @PostMapping("/schedules/big-seminar")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createBigSeminarSchedule(
+        requester: Requester,
+        @Valid @RequestBody request: CreateBigSeminarScheduleRequest,
+    ): CreateScheduleResponse {
+        val (schedule, bigSeminar) =
+            scheduleService.createBigSeminarSchedule(
+                requester = requester,
+                title = request.title,
+                location = request.location,
+                scheduledAt = request.scheduledAt,
+                endAt = request.endAt,
+                expoint = request.expoint,
+                generateCheckCode = request.generateCheckCode,
+                isSummerSeason = request.isSummerSeason,
+                isSpeakAfter = request.isSpeakAfter,
+            )
+        return CreateScheduleResponse.from(schedule, bigSeminar)
+    }
+
+    @Auth([UserRole.MANAGER])
+    @PatchMapping("/schedules/big-seminar/{scheduleId}")
+    fun updateBigSeminarSchedule(
+        requester: Requester,
+        @PathVariable scheduleId: Long,
+        @Valid @RequestBody request: UpdateBigSeminarScheduleRequest,
+    ): GetScheduleResponse {
+        val (schedule, bigSeminar) =
+            scheduleService.updateBigSeminarSchedule(
+                requester = requester,
+                id = scheduleId,
+                title = request.title,
+                location = request.location,
+                scheduledAt = request.scheduledAt,
+                endAt = request.endAt,
+                expoint = request.expoint,
+                isSummerSeason = request.isSummerSeason,
+                isSpeakAfter = request.isSpeakAfter,
+            )
+        return GetScheduleResponse.from(schedule, requester.role, bigSeminar)
+    }
+
+    @Auth([UserRole.MANAGER])
+    @DeleteMapping("/schedules/big-seminar/{scheduleId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteBigSeminarSchedule(
+        requester: Requester,
+        @PathVariable scheduleId: Long,
+    ) {
+        scheduleService.deleteBigSeminarSchedule(requester, scheduleId)
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/GroupActivityScheduleController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupActivityScheduleController.kt
@@ -1,0 +1,71 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.CreateGroupActivityScheduleRequest
+import com.sight.controllers.http.dto.CreateScheduleResponse
+import com.sight.controllers.http.dto.GetScheduleResponse
+import com.sight.controllers.http.dto.UpdateGroupActivityScheduleRequest
+import com.sight.core.auth.Auth
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
+import com.sight.service.ScheduleService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class GroupActivityScheduleController(
+    private val scheduleService: ScheduleService,
+) {
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @PostMapping("/schedules/group-activity")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createGroupActivitySchedule(
+        requester: Requester,
+        @Valid @RequestBody request: CreateGroupActivityScheduleRequest,
+    ): CreateScheduleResponse {
+        val schedule =
+            scheduleService.createGroupActivitySchedule(
+                requester = requester,
+                title = request.title,
+                location = request.location,
+                scheduledAt = request.scheduledAt,
+                endAt = request.endAt,
+            )
+        return CreateScheduleResponse.from(schedule)
+    }
+
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @PatchMapping("/schedules/group-activity/{scheduleId}")
+    fun updateGroupActivitySchedule(
+        requester: Requester,
+        @PathVariable scheduleId: Long,
+        @Valid @RequestBody request: UpdateGroupActivityScheduleRequest,
+    ): GetScheduleResponse {
+        val schedule =
+            scheduleService.updateGroupActivitySchedule(
+                requester = requester,
+                id = scheduleId,
+                title = request.title,
+                location = request.location,
+                scheduledAt = request.scheduledAt,
+                endAt = request.endAt,
+            )
+        return GetScheduleResponse.from(schedule, requester.role)
+    }
+
+    @Auth([UserRole.USER, UserRole.MANAGER])
+    @DeleteMapping("/schedules/group-activity/{scheduleId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteGroupActivitySchedule(
+        requester: Requester,
+        @PathVariable scheduleId: Long,
+    ) {
+        scheduleService.deleteGroupActivitySchedule(requester, scheduleId)
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/GroupActivityScheduleController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupActivityScheduleController.kt
@@ -36,6 +36,7 @@ class GroupActivityScheduleController(
                 location = request.location,
                 scheduledAt = request.scheduledAt,
                 endAt = request.endAt,
+                groupId = request.groupId,
             )
         return CreateScheduleResponse.from(schedule)
     }

--- a/src/main/kotlin/com/sight/controllers/http/ScheduleController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ScheduleController.kt
@@ -52,8 +52,8 @@ class ScheduleController(
         requester: Requester,
         @PathVariable scheduleId: Long,
     ): GetScheduleResponse {
-        val schedule = scheduleService.getScheduleById(scheduleId)
-        return GetScheduleResponse.from(schedule, requester.role)
+        val (schedule, authorName, groupTitle) = scheduleService.getScheduleWithDetails(scheduleId)
+        return GetScheduleResponse.from(schedule, requester.role, authorName = authorName, groupTitle = groupTitle)
     }
 
     @Auth([UserRole.MANAGER])

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateBigSeminarScheduleRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateBigSeminarScheduleRequest.kt
@@ -1,0 +1,21 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PositiveOrZero
+import java.time.LocalDateTime
+
+data class CreateBigSeminarScheduleRequest(
+    @field:NotBlank
+    val title: String,
+    val location: String?,
+    @field:NotNull
+    val scheduledAt: LocalDateTime,
+    @field:NotNull
+    val endAt: LocalDateTime,
+    @field:PositiveOrZero
+    val expoint: Int = 0,
+    val generateCheckCode: Boolean = false,
+    val isSummerSeason: Boolean,
+    val isSpeakAfter: Boolean,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateGroupActivityScheduleRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateGroupActivityScheduleRequest.kt
@@ -1,0 +1,15 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+data class CreateGroupActivityScheduleRequest(
+    @field:NotBlank
+    val title: String,
+    val location: String?,
+    @field:NotNull
+    val scheduledAt: LocalDateTime,
+    @field:NotNull
+    val endAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateGroupActivityScheduleRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateGroupActivityScheduleRequest.kt
@@ -12,4 +12,6 @@ data class CreateGroupActivityScheduleRequest(
     val scheduledAt: LocalDateTime,
     @field:NotNull
     val endAt: LocalDateTime,
+    @field:NotNull
+    val groupId: Long,
 )

--- a/src/main/kotlin/com/sight/controllers/http/dto/GetScheduleResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/GetScheduleResponse.kt
@@ -18,6 +18,9 @@ data class GetScheduleResponse(
     val expoint: Int,
     val checkCode: String?,
     val author: Long,
+    val authorName: String?,
+    val groupId: Long?,
+    val groupTitle: String?,
     val createdAt: String,
     val updatedAt: String,
     val isSummerSeason: Boolean?,
@@ -28,6 +31,8 @@ data class GetScheduleResponse(
             schedule: Schedule,
             role: UserRole,
             bigSeminar: BigSeminar? = null,
+            authorName: String? = null,
+            groupTitle: String? = null,
         ): GetScheduleResponse {
             return GetScheduleResponse(
                 id = schedule.id,
@@ -40,6 +45,9 @@ data class GetScheduleResponse(
                 expoint = schedule.expoint,
                 checkCode = if (role == UserRole.MANAGER) schedule.checkCode else null,
                 author = schedule.author,
+                authorName = authorName,
+                groupId = schedule.groupId,
+                groupTitle = groupTitle,
                 createdAt = schedule.createdAt.toString(),
                 updatedAt = schedule.updatedAt.toString(),
                 isSummerSeason = bigSeminar?.isSummerSeason,

--- a/src/main/kotlin/com/sight/controllers/http/dto/ListSchedulesResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/ListSchedulesResponse.kt
@@ -27,6 +27,7 @@ data class ScheduleDto(
     val endAt: String,
     val expoint: Int,
     val author: Long,
+    val groupId: Long?,
 ) {
     companion object {
         fun from(schedule: Schedule): ScheduleDto {
@@ -40,6 +41,7 @@ data class ScheduleDto(
                 endAt = schedule.endAt.toString(),
                 expoint = schedule.expoint,
                 author = schedule.author,
+                groupId = schedule.groupId,
             )
         }
     }

--- a/src/main/kotlin/com/sight/controllers/http/dto/UpdateBigSeminarScheduleRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/UpdateBigSeminarScheduleRequest.kt
@@ -1,0 +1,20 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PositiveOrZero
+import java.time.LocalDateTime
+
+data class UpdateBigSeminarScheduleRequest(
+    @field:NotBlank
+    val title: String,
+    val location: String?,
+    @field:NotNull
+    val scheduledAt: LocalDateTime,
+    @field:NotNull
+    val endAt: LocalDateTime,
+    @field:PositiveOrZero
+    val expoint: Int,
+    val isSummerSeason: Boolean,
+    val isSpeakAfter: Boolean,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/UpdateGroupActivityScheduleRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/UpdateGroupActivityScheduleRequest.kt
@@ -1,0 +1,15 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+data class UpdateGroupActivityScheduleRequest(
+    @field:NotBlank
+    val title: String,
+    val location: String?,
+    @field:NotNull
+    val scheduledAt: LocalDateTime,
+    @field:NotNull
+    val endAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/sight/core/exception/ConflictException.kt
+++ b/src/main/kotlin/com/sight/core/exception/ConflictException.kt
@@ -1,0 +1,12 @@
+package com.sight.core.exception
+
+import org.springframework.http.HttpStatus
+
+class ConflictException(
+    override val message: String,
+    override val data: Any? = null,
+) : BaseException(
+        statusCode = HttpStatus.CONFLICT,
+        message = message,
+        data = data,
+    )

--- a/src/main/kotlin/com/sight/domain/schedule/Schedule.kt
+++ b/src/main/kotlin/com/sight/domain/schedule/Schedule.kt
@@ -44,6 +44,9 @@ data class Schedule(
     @Column(name = "check_code", length = 255)
     val checkCode: String? = null,
 
+    @Column(name = "group_id")
+    val groupId: Long? = null,
+
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 

--- a/src/main/kotlin/com/sight/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ScheduleRepository.kt
@@ -32,4 +32,15 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
     fun deleteActiveById(
         @Param("id") id: Long,
     )
+
+    @Query(
+        "SELECT COUNT(s) FROM Schedule s " +
+            "WHERE s.location = :location AND s.state = 'public' " +
+            "AND s.scheduledAt < :endAt AND s.endAt > :scheduledAt",
+    )
+    fun countOverlappingAtLocation(
+        @Param("location") location: String,
+        @Param("scheduledAt") scheduledAt: LocalDateTime,
+        @Param("endAt") endAt: LocalDateTime,
+    ): Long
 }

--- a/src/main/kotlin/com/sight/service/ScheduleService.kt
+++ b/src/main/kotlin/com/sight/service/ScheduleService.kt
@@ -1,6 +1,9 @@
 package com.sight.service
 
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
 import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.ForbiddenException
 import com.sight.core.exception.NotFoundException
 import com.sight.domain.schedule.Schedule
 import com.sight.domain.schedule.ScheduleCategory
@@ -41,6 +44,26 @@ class ScheduleService(
     }
 
     @Transactional
+    fun createGroupActivitySchedule(
+        requester: Requester,
+        title: String,
+        location: String?,
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+    ): Schedule {
+        return saveNewSchedule(
+            requesterUserId = requester.userId,
+            title = title,
+            category = ScheduleCategory.GROUP_ACTIVITY,
+            location = location,
+            scheduledAt = scheduledAt,
+            endAt = endAt,
+            expoint = 0,
+            generateCheckCode = false,
+        )
+    }
+
+    @Transactional
     fun createSchedule(
         requesterUserId: Long,
         title: String,
@@ -58,6 +81,38 @@ class ScheduleService(
     }
 
     @Transactional
+    fun createBigSeminarSchedule(
+        requester: Requester,
+        title: String,
+        location: String?,
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+        expoint: Int,
+        generateCheckCode: Boolean,
+        isSummerSeason: Boolean,
+        isSpeakAfter: Boolean,
+    ): Pair<Schedule, BigSeminar> {
+        val schedule =
+            saveNewSchedule(requester.userId, title, ScheduleCategory.SEMINAR, location, scheduledAt, endAt, expoint, generateCheckCode)
+        val bigSeminar = upsertBigSeminar(schedule.id, isSummerSeason, isSpeakAfter)
+        return schedule to bigSeminar
+    }
+
+    @Transactional
+    fun updateGroupActivitySchedule(
+        requester: Requester,
+        id: Long,
+        title: String,
+        location: String?,
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+    ): Schedule {
+        val existing = findActiveScheduleInTier(id) { it.isGroupActivity }
+        assertUserIsAuthor(requester, existing)
+        return applyScheduleUpdate(existing, title, location, scheduledAt, endAt, existing.expoint)
+    }
+
+    @Transactional
     fun updateSchedule(
         id: Long,
         title: String,
@@ -68,6 +123,24 @@ class ScheduleService(
     ): Schedule {
         val existing = findActiveScheduleInTier(id) { it.isManagerCategory }
         return applyScheduleUpdate(existing, title, location, scheduledAt, endAt, expoint)
+    }
+
+    @Transactional
+    fun updateBigSeminarSchedule(
+        requester: Requester,
+        id: Long,
+        title: String,
+        location: String?,
+        scheduledAt: LocalDateTime,
+        endAt: LocalDateTime,
+        expoint: Int,
+        isSummerSeason: Boolean,
+        isSpeakAfter: Boolean,
+    ): Pair<Schedule, BigSeminar> {
+        val existing = findActiveScheduleInTier(id) { it.isSeminar }
+        val updated = applyScheduleUpdate(existing, title, location, scheduledAt, endAt, expoint)
+        val bigSeminar = upsertBigSeminar(updated.id, isSummerSeason, isSpeakAfter)
+        return updated to bigSeminar
     }
 
     @Transactional
@@ -103,9 +176,29 @@ class ScheduleService(
     }
 
     @Transactional
+    fun deleteGroupActivitySchedule(
+        requester: Requester,
+        id: Long,
+    ) {
+        val existing = findActiveScheduleInTier(id) { it.isGroupActivity }
+        assertUserIsAuthor(requester, existing)
+        scheduleRepository.deleteActiveById(existing.id)
+    }
+
+    @Transactional
     fun deleteSchedule(id: Long) {
         val existing = findActiveScheduleInTier(id) { it.isManagerCategory }
         scheduleRepository.deleteActiveById(existing.id)
+    }
+
+    @Transactional
+    fun deleteBigSeminarSchedule(
+        requester: Requester,
+        id: Long,
+    ) {
+        val existing = findActiveScheduleInTier(id) { it.isSeminar }
+        scheduleRepository.deleteActiveById(existing.id)
+        bigSeminarRepository.deleteByScheduleId(existing.id)
     }
 
     // ===== 공통 helper =====
@@ -186,6 +279,15 @@ class ScheduleService(
             throw BadRequestException("이 엔드포인트로 처리할 수 없는 카테고리의 일정입니다.")
         }
         return existing
+    }
+
+    private fun assertUserIsAuthor(
+        requester: Requester,
+        existing: Schedule,
+    ) {
+        if (requester.role == UserRole.USER && existing.author != requester.userId) {
+            throw ForbiddenException("본인이 작성한 일정만 수정·삭제할 수 있습니다.")
+        }
     }
 
     private fun validateTimeRange(

--- a/src/main/kotlin/com/sight/service/ScheduleService.kt
+++ b/src/main/kotlin/com/sight/service/ScheduleService.kt
@@ -3,13 +3,18 @@ package com.sight.service
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
 import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.ConflictException
 import com.sight.core.exception.ForbiddenException
 import com.sight.core.exception.NotFoundException
+import com.sight.domain.group.GroupState
 import com.sight.domain.schedule.Schedule
 import com.sight.domain.schedule.ScheduleCategory
 import com.sight.domain.schedule.ScheduleState
 import com.sight.domain.seminar.BigSeminar
 import com.sight.repository.BigSeminarRepository
+import com.sight.repository.GroupMemberRepository
+import com.sight.repository.GroupRepository
+import com.sight.repository.MemberRepository
 import com.sight.repository.ScheduleRepository
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
@@ -23,6 +28,9 @@ import kotlin.random.Random
 class ScheduleService(
     private val scheduleRepository: ScheduleRepository,
     private val bigSeminarRepository: BigSeminarRepository,
+    private val groupMemberRepository: GroupMemberRepository,
+    private val groupRepository: GroupRepository,
+    private val memberRepository: MemberRepository,
 ) {
     @Transactional(readOnly = true)
     fun listSchedules(
@@ -43,6 +51,16 @@ class ScheduleService(
             ?: throw NotFoundException("존재하지 않는 일정입니다.")
     }
 
+    @Transactional(readOnly = true)
+    fun getScheduleWithDetails(id: Long): Triple<Schedule, String, String?> {
+        val schedule =
+            scheduleRepository.findActiveById(id)
+                ?: throw NotFoundException("존재하지 않는 일정입니다.")
+        val authorName = memberRepository.findById(schedule.author).map { it.name }.orElse(null)
+        val groupTitle = schedule.groupId?.let { groupRepository.findById(it).map { g -> g.title }.orElse(null) }
+        return Triple(schedule, authorName ?: "알 수 없음", groupTitle)
+    }
+
     @Transactional
     fun createGroupActivitySchedule(
         requester: Requester,
@@ -50,7 +68,16 @@ class ScheduleService(
         location: String?,
         scheduledAt: LocalDateTime,
         endAt: LocalDateTime,
+        groupId: Long,
     ): Schedule {
+        val group =
+            groupRepository.findById(groupId).orElseThrow { NotFoundException("존재하지 않는 그룹입니다.") }
+        if (group.state != GroupState.PROGRESS) {
+            throw BadRequestException("진행 중인 그룹만 그룹 활동 일정을 등록할 수 있습니다.")
+        }
+        if (!groupMemberRepository.existsByGroupIdAndMemberId(groupId, requester.userId)) {
+            throw ForbiddenException("해당 그룹의 멤버만 그룹 활동 일정을 등록할 수 있습니다.")
+        }
         return saveNewSchedule(
             requesterUserId = requester.userId,
             title = title,
@@ -60,6 +87,7 @@ class ScheduleService(
             endAt = endAt,
             expoint = 0,
             generateCheckCode = false,
+            groupId = groupId,
         )
     }
 
@@ -108,7 +136,7 @@ class ScheduleService(
         endAt: LocalDateTime,
     ): Schedule {
         val existing = findActiveScheduleInTier(id) { it.isGroupActivity }
-        assertUserIsAuthor(requester, existing)
+        assertIsAuthor(requester, existing)
         return applyScheduleUpdate(existing, title, location, scheduledAt, endAt, existing.expoint)
     }
 
@@ -181,7 +209,7 @@ class ScheduleService(
         id: Long,
     ) {
         val existing = findActiveScheduleInTier(id) { it.isGroupActivity }
-        assertUserIsAuthor(requester, existing)
+        assertIsAuthorOrManager(requester, existing)
         scheduleRepository.deleteActiveById(existing.id)
     }
 
@@ -212,8 +240,14 @@ class ScheduleService(
         endAt: LocalDateTime,
         expoint: Int,
         generateCheckCode: Boolean,
+        groupId: Long? = null,
     ): Schedule {
         validateTimeRange(scheduledAt, endAt)
+        if (location != null && location in CLUB_ROOM_LOCATIONS) {
+            if (scheduleRepository.countOverlappingAtLocation(location, scheduledAt, endAt) > 0) {
+                throw ConflictException("해당 장소에 시간이 겹치는 일정이 이미 있습니다.")
+            }
+        }
         val schedule =
             Schedule(
                 id = pickAvailableScheduleId(),
@@ -226,6 +260,7 @@ class ScheduleService(
                 location = location,
                 expoint = expoint,
                 checkCode = if (generateCheckCode) createCheckCode() else null,
+                groupId = groupId,
             )
         return scheduleRepository.save(schedule)
     }
@@ -281,12 +316,21 @@ class ScheduleService(
         return existing
     }
 
-    private fun assertUserIsAuthor(
+    private fun assertIsAuthor(
+        requester: Requester,
+        existing: Schedule,
+    ) {
+        if (existing.author != requester.userId) {
+            throw ForbiddenException("본인이 작성한 일정만 수정할 수 있습니다.")
+        }
+    }
+
+    private fun assertIsAuthorOrManager(
         requester: Requester,
         existing: Schedule,
     ) {
         if (requester.role == UserRole.USER && existing.author != requester.userId) {
-            throw ForbiddenException("본인이 작성한 일정만 수정·삭제할 수 있습니다.")
+            throw ForbiddenException("본인이 작성한 일정만 삭제할 수 있습니다.")
         }
     }
 
@@ -323,5 +367,6 @@ class ScheduleService(
     companion object {
         private val KST: ZoneId = ZoneId.of("Asia/Seoul")
         private const val MAX_SCHEDULE_ID_RETRY = 3
+        private val CLUB_ROOM_LOCATIONS = setOf("405", "406", "410")
     }
 }

--- a/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
@@ -3,13 +3,24 @@ package com.sight.service
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
 import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.ConflictException
 import com.sight.core.exception.ForbiddenException
 import com.sight.core.exception.NotFoundException
+import com.sight.domain.group.Group
+import com.sight.domain.group.GroupAccessGrade
+import com.sight.domain.group.GroupCategory
+import com.sight.domain.group.GroupState
+import com.sight.domain.member.Member
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
 import com.sight.domain.schedule.Schedule
 import com.sight.domain.schedule.ScheduleCategory
 import com.sight.domain.schedule.ScheduleState
 import com.sight.domain.seminar.BigSeminar
 import com.sight.repository.BigSeminarRepository
+import com.sight.repository.GroupMemberRepository
+import com.sight.repository.GroupRepository
+import com.sight.repository.MemberRepository
 import com.sight.repository.ScheduleRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,8 +28,10 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import java.time.LocalDateTime
+import java.util.Optional
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -27,6 +40,9 @@ import kotlin.test.assertTrue
 class ScheduleServiceTest {
     private val scheduleRepository: ScheduleRepository = mock()
     private val bigSeminarRepository: BigSeminarRepository = mock()
+    private val groupMemberRepository: GroupMemberRepository = mock()
+    private val groupRepository: GroupRepository = mock()
+    private val memberRepository: MemberRepository = mock()
     private lateinit var scheduleService: ScheduleService
 
     @BeforeEach
@@ -35,6 +51,9 @@ class ScheduleServiceTest {
             ScheduleService(
                 scheduleRepository = scheduleRepository,
                 bigSeminarRepository = bigSeminarRepository,
+                groupMemberRepository = groupMemberRepository,
+                groupRepository = groupRepository,
+                memberRepository = memberRepository,
             )
     }
 
@@ -125,6 +144,85 @@ class ScheduleServiceTest {
         assertThrows<NotFoundException> {
             scheduleService.getScheduleById(999L)
         }
+    }
+
+    @Test
+    fun `getScheduleWithDetails는 작성자명과 그룹명을 함께 반환한다`() {
+        val schedule =
+            Schedule(
+                id = 1L,
+                category = ScheduleCategory.GROUP_ACTIVITY,
+                title = "스터디",
+                author = 10L,
+                state = ScheduleState.PUBLIC,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                groupId = 20L,
+            )
+        val member =
+            Member(
+                id = 10L,
+                name = "khlug_user",
+                admission = "21",
+                realname = "홍길동",
+                college = "소프트웨어융합대학",
+                grade = 3L,
+                studentStatus = StudentStatus.UNDERGRADUATE,
+                status = UserStatus.ACTIVE,
+            )
+        val group =
+            Group(
+                id = 20L,
+                category = GroupCategory.STUDY,
+                title = "코틀린 스터디",
+                author = 10L,
+                master = 10L,
+                state = GroupState.PROGRESS,
+                grade = GroupAccessGrade.MEMBER,
+            )
+        given(scheduleRepository.findActiveById(1L)).willReturn(schedule)
+        given(memberRepository.findById(10L)).willReturn(Optional.of(member))
+        given(groupRepository.findById(20L)).willReturn(Optional.of(group))
+
+        val (resultSchedule, authorName, groupTitle) = scheduleService.getScheduleWithDetails(1L)
+
+        assertEquals(1L, resultSchedule.id)
+        assertEquals("khlug_user", authorName)
+        assertEquals("코틀린 스터디", groupTitle)
+    }
+
+    @Test
+    fun `getScheduleWithDetails는 groupId가 null이면 groupTitle이 null이다`() {
+        val schedule =
+            Schedule(
+                id = 1L,
+                category = ScheduleCategory.CLUB,
+                title = "동아리 모임",
+                author = 10L,
+                state = ScheduleState.PUBLIC,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                groupId = null,
+            )
+        val member =
+            Member(
+                id = 10L,
+                name = "khlug_user",
+                admission = "21",
+                realname = "홍길동",
+                college = "소프트웨어융합대학",
+                grade = 3L,
+                studentStatus = StudentStatus.UNDERGRADUATE,
+                status = UserStatus.ACTIVE,
+            )
+        given(scheduleRepository.findActiveById(1L)).willReturn(schedule)
+        given(memberRepository.findById(10L)).willReturn(Optional.of(member))
+
+        val (_, authorName, groupTitle) = scheduleService.getScheduleWithDetails(1L)
+
+        assertEquals("khlug_user", authorName)
+        assertNull(groupTitle)
+        verify(groupRepository, never()).findById(any())
     }
 
     @Test
@@ -358,8 +456,83 @@ class ScheduleServiceTest {
     }
 
     @Test
-    fun `createGroupActivitySchedule은 GROUP_ACTIVITY로 expoint 0 checkCode 없이 생성한다`() {
+    fun `createSchedule은 동방 장소에 시간이 겹치는 일정이 있으면 ConflictException을 던진다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+        given(scheduleRepository.countOverlappingAtLocation(any(), any(), any())).willReturn(1L)
+
+        assertThrows<ConflictException> {
+            scheduleService.createSchedule(
+                requesterUserId = requester.userId,
+                title = "test",
+                category = ScheduleCategory.CLUB,
+                location = "405",
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 0,
+                generateCheckCode = false,
+            )
+        }
+        verify(scheduleRepository, never()).save(any())
+    }
+
+    @Test
+    fun `createSchedule은 동방 장소라도 시간이 겹치지 않으면 정상 등록한다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+        given(scheduleRepository.countOverlappingAtLocation(any(), any(), any())).willReturn(0L)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+
+        val result =
+            scheduleService.createSchedule(
+                requesterUserId = requester.userId,
+                title = "test",
+                category = ScheduleCategory.CLUB,
+                location = "406",
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 0,
+                generateCheckCode = false,
+            )
+
+        assertEquals("406", result.location)
+        verify(scheduleRepository).save(any<Schedule>())
+    }
+
+    @Test
+    fun `createSchedule은 동방 이외의 장소는 시간이 겹쳐도 등록을 허용한다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+
+        val result =
+            scheduleService.createSchedule(
+                requesterUserId = requester.userId,
+                title = "test",
+                category = ScheduleCategory.CLUB,
+                location = "기타 장소",
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 0,
+                generateCheckCode = false,
+            )
+
+        assertEquals("기타 장소", result.location)
+        verify(scheduleRepository, never()).countOverlappingAtLocation(any(), any(), any())
+    }
+
+    @Test
+    fun `createGroupActivitySchedule은 그룹 멤버이면 GROUP_ACTIVITY로 expoint 0 checkCode 없이 생성한다`() {
         val requester = Requester(userId = 1L, role = UserRole.USER)
+        val group =
+            Group(
+                id = 10L,
+                category = GroupCategory.STUDY,
+                title = "스터디",
+                author = 1L,
+                master = 1L,
+                state = GroupState.PROGRESS,
+                grade = GroupAccessGrade.MEMBER,
+            )
+        given(groupRepository.findById(10L)).willReturn(Optional.of(group))
+        given(groupMemberRepository.existsByGroupIdAndMemberId(10L, 1L)).willReturn(true)
         given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
 
         val result =
@@ -369,12 +542,44 @@ class ScheduleServiceTest {
                 location = null,
                 scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
                 endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                groupId = 10L,
             )
 
         assertEquals(ScheduleCategory.GROUP_ACTIVITY, result.category)
         assertEquals(0, result.expoint)
         assertEquals(1L, result.author)
+        assertEquals(10L, result.groupId)
         assertNull(result.checkCode)
+    }
+
+    @Test
+    fun `createGroupActivitySchedule은 해당 그룹 멤버가 아니면 ForbiddenException을 던진다`() {
+        val requester = Requester(userId = 1L, role = UserRole.USER)
+        val group =
+            Group(
+                id = 10L,
+                category = GroupCategory.STUDY,
+                title = "스터디",
+                author = 1L,
+                master = 1L,
+                state = GroupState.PROGRESS,
+                grade = GroupAccessGrade.MEMBER,
+            )
+        given(groupRepository.findById(10L)).willReturn(Optional.of(group))
+        given(groupMemberRepository.existsByGroupIdAndMemberId(10L, 1L)).willReturn(false)
+
+        assertThrows<ForbiddenException> {
+            scheduleService.createGroupActivitySchedule(
+                requester = requester,
+                title = "스터디",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                groupId = 10L,
+            )
+        }
+
+        verify(scheduleRepository, never()).save(any())
     }
 
     @Test
@@ -428,6 +633,44 @@ class ScheduleServiceTest {
         val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY, author = 10L)
         given(scheduleRepository.findActiveById(1L)).willReturn(existing)
         val requester = Requester(userId = 99L, role = UserRole.USER)
+
+        assertThrows<ForbiddenException> {
+            scheduleService.updateGroupActivitySchedule(
+                requester = requester,
+                id = 1L,
+                title = "x",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+            )
+        }
+    }
+
+    @Test
+    fun `updateGroupActivitySchedule은 MANAGER가 본인 작성 그룹활동을 수정한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY, author = 10L)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        val requester = Requester(userId = 10L, role = UserRole.MANAGER)
+
+        val result =
+            scheduleService.updateGroupActivitySchedule(
+                requester = requester,
+                id = 1L,
+                title = "new",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 20, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 20, 16, 0),
+            )
+
+        assertEquals("new", result.title)
+    }
+
+    @Test
+    fun `updateGroupActivitySchedule은 MANAGER가 타인 작성 일정을 수정하면 ForbiddenException 던진다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY, author = 10L)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 99L, role = UserRole.MANAGER)
 
         assertThrows<ForbiddenException> {
             scheduleService.updateGroupActivitySchedule(
@@ -527,6 +770,17 @@ class ScheduleServiceTest {
         assertThrows<ForbiddenException> {
             scheduleService.deleteGroupActivitySchedule(requester, 1L)
         }
+    }
+
+    @Test
+    fun `deleteGroupActivitySchedule은 MANAGER가 타인 작성 그룹활동을 삭제한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY, author = 10L)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 99L, role = UserRole.MANAGER)
+
+        scheduleService.deleteGroupActivitySchedule(requester, 1L)
+
+        verify(scheduleRepository).deleteActiveById(1L)
     }
 
     @Test

--- a/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ScheduleServiceTest.kt
@@ -1,6 +1,9 @@
 package com.sight.service
 
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
 import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.ForbiddenException
 import com.sight.core.exception.NotFoundException
 import com.sight.domain.schedule.Schedule
 import com.sight.domain.schedule.ScheduleCategory
@@ -352,6 +355,190 @@ class ScheduleServiceTest {
         assertThrows<NotFoundException> {
             scheduleService.deleteSchedule(999L)
         }
+    }
+
+    @Test
+    fun `createGroupActivitySchedule은 GROUP_ACTIVITY로 expoint 0 checkCode 없이 생성한다`() {
+        val requester = Requester(userId = 1L, role = UserRole.USER)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+
+        val result =
+            scheduleService.createGroupActivitySchedule(
+                requester = requester,
+                title = "스터디",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+            )
+
+        assertEquals(ScheduleCategory.GROUP_ACTIVITY, result.category)
+        assertEquals(0, result.expoint)
+        assertEquals(1L, result.author)
+        assertNull(result.checkCode)
+    }
+
+    @Test
+    fun `createBigSeminarSchedule은 SEMINAR 일정과 빅세미나 레코드를 함께 생성한다`() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        given(bigSeminarRepository.save(any<BigSeminar>())).willAnswer { it.arguments[0] as BigSeminar }
+
+        val (schedule, bigSeminar) =
+            scheduleService.createBigSeminarSchedule(
+                requester = requester,
+                title = "총회",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 50,
+                generateCheckCode = false,
+                isSummerSeason = true,
+                isSpeakAfter = false,
+            )
+
+        assertEquals(ScheduleCategory.SEMINAR, schedule.category)
+        assertEquals(schedule.id, bigSeminar.scheduleId)
+        assertTrue(bigSeminar.isSummerSeason)
+        verify(bigSeminarRepository).save(any<BigSeminar>())
+    }
+
+    @Test
+    fun `updateGroupActivitySchedule은 본인 작성 그룹활동을 수정한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY, author = 10L)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        val requester = Requester(userId = 10L, role = UserRole.USER)
+
+        val result =
+            scheduleService.updateGroupActivitySchedule(
+                requester = requester,
+                id = 1L,
+                title = "new",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 20, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 20, 16, 0),
+            )
+
+        assertEquals("new", result.title)
+        assertEquals(ScheduleCategory.GROUP_ACTIVITY, result.category)
+    }
+
+    @Test
+    fun `updateGroupActivitySchedule은 USER가 타인 작성 일정을 수정하면 ForbiddenException 던진다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY, author = 10L)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 99L, role = UserRole.USER)
+
+        assertThrows<ForbiddenException> {
+            scheduleService.updateGroupActivitySchedule(
+                requester = requester,
+                id = 1L,
+                title = "x",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+            )
+        }
+    }
+
+    @Test
+    fun `updateGroupActivitySchedule은 대상이 그룹활동이 아니면 BadRequestException 던진다`() {
+        val existing = scheduleOf(category = ScheduleCategory.CLUB, author = 10L)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 10L, role = UserRole.MANAGER)
+
+        assertThrows<BadRequestException> {
+            scheduleService.updateGroupActivitySchedule(
+                requester = requester,
+                id = 1L,
+                title = "x",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+            )
+        }
+    }
+
+    @Test
+    fun `updateBigSeminarSchedule은 세미나 일정과 빅세미나 정보를 갱신한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.SEMINAR)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        given(scheduleRepository.save(any<Schedule>())).willAnswer { it.arguments[0] as Schedule }
+        given(bigSeminarRepository.findByScheduleId(1L)).willReturn(null)
+        given(bigSeminarRepository.save(any<BigSeminar>())).willAnswer { it.arguments[0] as BigSeminar }
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        val (schedule, bigSeminar) =
+            scheduleService.updateBigSeminarSchedule(
+                requester = requester,
+                id = 1L,
+                title = "new",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 20, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 20, 16, 0),
+                expoint = 50,
+                isSummerSeason = false,
+                isSpeakAfter = true,
+            )
+
+        assertEquals("new", schedule.title)
+        assertEquals(ScheduleCategory.SEMINAR, schedule.category)
+        assertTrue(bigSeminar.isSpeakAfter)
+    }
+
+    @Test
+    fun `updateBigSeminarSchedule은 대상이 세미나가 아니면 BadRequestException 던진다`() {
+        val existing = scheduleOf(category = ScheduleCategory.CLUB)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        assertThrows<BadRequestException> {
+            scheduleService.updateBigSeminarSchedule(
+                requester = requester,
+                id = 1L,
+                title = "x",
+                location = null,
+                scheduledAt = LocalDateTime.of(2026, 5, 18, 14, 0),
+                endAt = LocalDateTime.of(2026, 5, 18, 16, 0),
+                expoint = 0,
+                isSummerSeason = true,
+                isSpeakAfter = true,
+            )
+        }
+    }
+
+    @Test
+    fun `deleteGroupActivitySchedule은 본인 작성 그룹활동을 삭제한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY, author = 10L)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 10L, role = UserRole.USER)
+
+        scheduleService.deleteGroupActivitySchedule(requester, 1L)
+
+        verify(scheduleRepository).deleteActiveById(1L)
+    }
+
+    @Test
+    fun `deleteGroupActivitySchedule은 USER가 타인 작성 일정을 삭제하면 ForbiddenException 던진다`() {
+        val existing = scheduleOf(category = ScheduleCategory.GROUP_ACTIVITY, author = 10L)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 99L, role = UserRole.USER)
+
+        assertThrows<ForbiddenException> {
+            scheduleService.deleteGroupActivitySchedule(requester, 1L)
+        }
+    }
+
+    @Test
+    fun `deleteBigSeminarSchedule은 세미나 일정과 빅세미나를 삭제한다`() {
+        val existing = scheduleOf(category = ScheduleCategory.SEMINAR)
+        given(scheduleRepository.findActiveById(1L)).willReturn(existing)
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+
+        scheduleService.deleteBigSeminarSchedule(requester, 1L)
+
+        verify(scheduleRepository).deleteActiveById(1L)
+        verify(bigSeminarRepository).deleteByScheduleId(1L)
     }
 
     private fun scheduleOf(


### PR DESCRIPTION
## Summary
- `POST/PATCH/DELETE /schedules/group-activity`: 그룹 활동 일정 CRUD (USER 권한 허용)
- `POST/PATCH/DELETE /schedules/big-seminar`: MANAGER 전용, 빅세미나(BigSeminar) 레코드를 동반 처리

## 추가 보완
- 상세 조회에 작성자명·그룹명 포함
- 그룹 활동 등록 시 그룹 존재(404)·진행 상태(400)·멤버(403) 검증
- 수정 권한 강화 (수정=작성자 한정, 삭제=운영진도 가능)
- 동방(405/406/410) 장소 시간 중복 등록 방지 (409)

## Test plan
- [x] `ScheduleServiceTest`: CRUD 6종 + 보완 fix 관련 신규 케이스(권한·그룹 검증·중복 방지) 추가
- [x] `./gradlew ktlintCheck` 통과

> base는 `feat/schedule-crud-common` (stacked PR). 명세는 PR #157 참조.
