### PR TITLE
feat: 도어락 출입 보고·회원 명단·데몬 다운 알림 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/DoorLockAccessController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/DoorLockAccessController.kt
@@ -1,0 +1,29 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.CreateDoorLockAccessRequest
+import com.sight.controllers.http.dto.CreateDoorLockAccessResponse
+import com.sight.core.auth.Auth
+import com.sight.core.auth.UserRole
+import com.sight.service.DoorLockAccessService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DoorLockAccessController(
+    private val doorLockAccessService: DoorLockAccessService,
+) {
+    @Auth([UserRole.SYSTEM])
+    @PostMapping("/internal/door-lock/accesses")
+    fun createDoorLockAccess(
+        @Valid @RequestBody request: CreateDoorLockAccessRequest,
+    ): CreateDoorLockAccessResponse {
+        val result =
+            doorLockAccessService.createDoorLockAccess(
+                number = request.number!!,
+                roomNumber = request.roomNumber!!,
+            )
+        return CreateDoorLockAccessResponse(name = result.name)
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/DoorLockAccessController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/DoorLockAccessController.kt
@@ -5,14 +5,18 @@ import com.sight.controllers.http.dto.CreateDoorLockAccessResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.UserRole
 import com.sight.service.DoorLockAccessService
+import com.sight.service.DoorLockAlertService
 import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class DoorLockAccessController(
     private val doorLockAccessService: DoorLockAccessService,
+    private val doorLockAlertService: DoorLockAlertService,
 ) {
     @Auth([UserRole.SYSTEM])
     @PostMapping("/internal/door-lock/accesses")
@@ -25,5 +29,12 @@ class DoorLockAccessController(
                 roomNumber = request.roomNumber!!,
             )
         return CreateDoorLockAccessResponse(name = result.name)
+    }
+
+    @Auth([UserRole.SYSTEM])
+    @PostMapping("/internal/door-lock/alert-die")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun alertDoorLockDie() {
+        doorLockAlertService.alertDie()
     }
 }

--- a/src/main/kotlin/com/sight/controllers/http/InternalDoorLockController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/InternalDoorLockController.kt
@@ -1,0 +1,24 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.ListDoorLockMemberResponse
+import com.sight.controllers.http.dto.toDoorLockMemberResponse
+import com.sight.core.auth.Auth
+import com.sight.core.auth.UserRole
+import com.sight.service.DoorLockMemberService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class InternalDoorLockController(
+    private val doorLockMemberService: DoorLockMemberService,
+) {
+    @Auth(roles = [UserRole.SYSTEM])
+    @GetMapping("/internal/door-lock/members")
+    fun listDoorLockMembers(): ListDoorLockMemberResponse {
+        val members = doorLockMemberService.listDoorLockMembers()
+        return ListDoorLockMemberResponse(
+            count = members.size.toLong(),
+            members = members.map { it.toDoorLockMemberResponse() },
+        )
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateDoorLockAccessRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateDoorLockAccessRequest.kt
@@ -1,0 +1,14 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+
+data class CreateDoorLockAccessRequest(
+    @field:NotNull(message = "학번은 필수입니다")
+    @field:Positive(message = "학번은 양수여야 합니다")
+    val number: Long?,
+
+    @field:NotNull(message = "방 번호는 필수입니다")
+    @field:Positive(message = "방 번호는 양수여야 합니다")
+    val roomNumber: Int?,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateDoorLockAccessResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateDoorLockAccessResponse.kt
@@ -1,0 +1,5 @@
+package com.sight.controllers.http.dto
+
+data class CreateDoorLockAccessResponse(
+    val name: String,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/ListDoorLockMemberResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/ListDoorLockMemberResponse.kt
@@ -1,0 +1,19 @@
+package com.sight.controllers.http.dto
+
+import com.sight.domain.member.Member
+
+data class ListDoorLockMemberResponse(
+    val count: Long,
+    val members: List<DoorLockMemberResponse>,
+)
+
+data class DoorLockMemberResponse(
+    val name: String,
+    val number: Long,
+)
+
+fun Member.toDoorLockMemberResponse(): DoorLockMemberResponse =
+    DoorLockMemberResponse(
+        name = realname,
+        number = number!!,
+    )

--- a/src/main/kotlin/com/sight/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/sight/repository/MemberRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface MemberRepository : JpaRepository<Member, Long>, MemberRepositoryCustom {
     fun findByManagerTrue(): List<Member>
+
+    fun findByNumberIsNotNull(): List<Member>
 }

--- a/src/main/kotlin/com/sight/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/sight/repository/MemberRepository.kt
@@ -1,7 +1,9 @@
 package com.sight.repository
 
 import com.sight.domain.member.Member
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -9,4 +11,7 @@ interface MemberRepository : JpaRepository<Member, Long>, MemberRepositoryCustom
     fun findByManagerTrue(): List<Member>
 
     fun findByNumberIsNotNull(): List<Member>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findByNumber(number: Long): Member?
 }

--- a/src/main/kotlin/com/sight/service/DoorLockAccessService.kt
+++ b/src/main/kotlin/com/sight/service/DoorLockAccessService.kt
@@ -1,0 +1,55 @@
+package com.sight.service
+
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.NotFoundException
+import com.sight.repository.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+data class CreateDoorLockAccessResult(
+    val name: String,
+)
+
+@Service
+class DoorLockAccessService(
+    private val memberRepository: MemberRepository,
+    private val pointService: PointService,
+) {
+    @Transactional
+    fun createDoorLockAccess(
+        number: Long,
+        roomNumber: Int,
+        now: LocalDateTime = LocalDateTime.now(KST),
+    ): CreateDoorLockAccessResult {
+        if (number <= 0) {
+            throw BadRequestException("학번은 양수여야 합니다")
+        }
+        if (roomNumber <= 0) {
+            throw BadRequestException("방 번호는 양수여야 합니다")
+        }
+
+        val member =
+            memberRepository.findByNumber(number)
+                ?: throw NotFoundException("사용자를 찾을 수 없습니다")
+        val isFirstAccessToday = member.lastEnter.toLocalDate() != now.toLocalDate()
+
+        memberRepository.save(member.copy(lastEnter = now))
+
+        if (isFirstAccessToday) {
+            pointService.givePoint(
+                targetUserId = member.id,
+                point = DOOR_LOCK_ACCESS_EXPOINT,
+                message = "동방 출입",
+            )
+        }
+
+        return CreateDoorLockAccessResult(name = member.realname)
+    }
+
+    companion object {
+        private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+        private const val DOOR_LOCK_ACCESS_EXPOINT = 1
+    }
+}

--- a/src/main/kotlin/com/sight/service/DoorLockAlertService.kt
+++ b/src/main/kotlin/com/sight/service/DoorLockAlertService.kt
@@ -1,0 +1,47 @@
+package com.sight.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+
+@Service
+class DoorLockAlertService(
+    @param:Value("\${khlug.door-lock.webhook-url:}")
+    private val webhookUrl: String,
+    @param:Qualifier("discordRestTemplate")
+    private val restTemplate: RestTemplate,
+) {
+    private val logger = LoggerFactory.getLogger(DoorLockAlertService::class.java)
+
+    fun alertDie() {
+        if (webhookUrl.isBlank()) {
+            logger.warn("도어락 알림 웹훅 URL이 설정되지 않았습니다")
+            return
+        }
+
+        try {
+            val headers =
+                HttpHeaders().apply {
+                    contentType = MediaType.APPLICATION_JSON
+                }
+            val payload = mapOf("content" to ALERT_MESSAGE)
+
+            restTemplate.postForEntity(
+                webhookUrl,
+                HttpEntity(payload, headers),
+                String::class.java,
+            )
+        } catch (e: Exception) {
+            logger.error("도어락 데몬 응답 없음 알림 전송 실패", e)
+        }
+    }
+
+    companion object {
+        private const val ALERT_MESSAGE = "🔴 도어락 데몬 응답 없음 - 라즈베리파이 또는 Flask 데몬 상태를 확인하세요."
+    }
+}

--- a/src/main/kotlin/com/sight/service/DoorLockMemberService.kt
+++ b/src/main/kotlin/com/sight/service/DoorLockMemberService.kt
@@ -1,0 +1,18 @@
+package com.sight.service
+
+import com.sight.domain.member.Member
+import com.sight.repository.MemberRepository
+import org.springframework.stereotype.Service
+
+@Service
+class DoorLockMemberService(
+    private val memberRepository: MemberRepository,
+) {
+    /**
+     * 도어락 출입 검증 대상 회원 명단을 조회한다.
+     *
+     * 학번(`number`)이 없는 회원은 출입 검증 대상이 될 수 없으므로 제외한다.
+     * 제명·탈퇴 회원은 학번이 0으로 초기화되므로(null 아님) 함께 제외한다.
+     */
+    fun listDoorLockMembers(): List<Member> = memberRepository.findByNumberIsNotNull().filter { it.number != 0L }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,8 @@ discord:
     group: ${DISCORD_GROUP_CATEGORY:}
 
 khlug:
+  door-lock:
+    webhook-url: ${DOOR_LOCK_ALERT_DISCORD_WEBHOOK:}
   phone:
     webhook-url: ${SYSTEM_ALERT_DISCORD_WEBHOOK:}
 
@@ -119,6 +121,8 @@ discord:
     group: ${DISCORD_GROUP_CATEGORY:}
 
 khlug:
+  door-lock:
+    webhook-url: ${DOOR_LOCK_ALERT_DISCORD_WEBHOOK:}
   phone:
     webhook-url: ${SYSTEM_ALERT_DISCORD_WEBHOOK:}
 

--- a/src/test/kotlin/com/sight/controllers/http/InternalDoorLockControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/InternalDoorLockControllerTest.kt
@@ -1,0 +1,81 @@
+package com.sight.controllers.http
+
+import com.sight.domain.member.Member
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
+import com.sight.service.DoorLockMemberService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(InternalDoorLockController::class, excludeAutoConfiguration = [SecurityAutoConfiguration::class])
+class InternalDoorLockControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var doorLockMemberService: DoorLockMemberService
+
+    private fun member(
+        id: Long,
+        realname: String,
+        number: Long?,
+    ): Member =
+        Member(
+            id = id,
+            name = "user$id",
+            realname = realname,
+            number = number,
+            studentStatus = StudentStatus.UNDERGRADUATE,
+            status = UserStatus.ACTIVE,
+        )
+
+    @Test
+    fun `회원 명단을 이름과 학번으로 반환한다`() {
+        given(doorLockMemberService.listDoorLockMembers()).willReturn(
+            listOf(
+                member(1L, "김철수", 2020001L),
+                member(2L, "이영희", 2020002L),
+            ),
+        )
+
+        mockMvc.perform(get("/internal/door-lock/members"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.count").value(2))
+            .andExpect(jsonPath("$.members[0].name").value("김철수"))
+            .andExpect(jsonPath("$.members[0].number").value(2020001))
+            .andExpect(jsonPath("$.members[1].name").value("이영희"))
+            .andExpect(jsonPath("$.members[1].number").value(2020002))
+    }
+
+    @Test
+    fun `응답에는 이메일·전화번호 등 도어락에 불필요한 필드가 포함되지 않는다`() {
+        given(doorLockMemberService.listDoorLockMembers()).willReturn(
+            listOf(member(1L, "김철수", 2020001L)),
+        )
+
+        mockMvc.perform(get("/internal/door-lock/members"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.members[0].email").doesNotExist())
+            .andExpect(jsonPath("$.members[0].phone").doesNotExist())
+            .andExpect(jsonPath("$.members[0].id").doesNotExist())
+    }
+
+    @Test
+    fun `명단 대상 회원이 없으면 count가 0인 빈 배열을 반환한다`() {
+        given(doorLockMemberService.listDoorLockMembers()).willReturn(emptyList())
+
+        mockMvc.perform(get("/internal/door-lock/members"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.count").value(0))
+            .andExpect(jsonPath("$.members").isArray)
+            .andExpect(jsonPath("$.members").isEmpty)
+    }
+}

--- a/src/test/kotlin/com/sight/service/DoorLockAccessServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/DoorLockAccessServiceTest.kt
@@ -1,0 +1,107 @@
+package com.sight.service
+
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.NotFoundException
+import com.sight.domain.member.Member
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
+import com.sight.repository.MemberRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+class DoorLockAccessServiceTest {
+    private val memberRepository: MemberRepository = mock()
+    private val pointService: PointService = mock()
+    private val service = DoorLockAccessService(memberRepository, pointService)
+
+    @Test
+    fun `오늘 첫 출입이면 ExPoint를 적립하고 회원 이름을 반환한다`() {
+        val member = member(lastEnter = LocalDateTime.of(2026, 5, 30, 23, 0))
+        val number = member.number!!
+        given(memberRepository.findByNumber(number)).willReturn(member)
+
+        val result = service.createDoorLockAccess(number, 406, LocalDateTime.of(2026, 5, 31, 10, 0))
+
+        assertEquals(member.realname, result.name)
+        verify(pointService).givePoint(member.id, 1, "동방 출입")
+        val captor = argumentCaptor<Member>()
+        verify(memberRepository).save(captor.capture())
+        assertEquals(LocalDateTime.of(2026, 5, 31, 10, 0), captor.firstValue.lastEnter)
+    }
+
+    @Test
+    fun `같은 날 두 번째 이후 출입은 ExPoint를 적립하지 않는다`() {
+        val member = member(lastEnter = LocalDateTime.of(2026, 5, 31, 9, 0))
+        val number = member.number!!
+        given(memberRepository.findByNumber(number)).willReturn(member)
+
+        val result = service.createDoorLockAccess(number, 406, LocalDateTime.of(2026, 5, 31, 10, 0))
+
+        assertEquals(member.realname, result.name)
+        verify(pointService, never()).givePoint(any(), any(), any())
+        verify(memberRepository).save(any<Member>())
+    }
+
+    @Test
+    fun `학번에 해당하는 사용자가 없으면 NotFoundException을 던진다`() {
+        given(memberRepository.findByNumber(2026000000L)).willReturn(null)
+
+        assertThrows<NotFoundException> {
+            service.createDoorLockAccess(2026000000L, 406)
+        }
+
+        verify(memberRepository, never()).save(any<Member>())
+        verify(pointService, never()).givePoint(any(), any(), any())
+    }
+
+    @Test
+    fun `학번이나 방 번호가 양수가 아니면 BadRequestException을 던진다`() {
+        assertThrows<BadRequestException> {
+            service.createDoorLockAccess(0L, 406)
+        }
+        assertThrows<BadRequestException> {
+            service.createDoorLockAccess(2026000000L, 0)
+        }
+
+        verify(memberRepository, never()).findByNumber(any())
+        verify(pointService, never()).givePoint(any(), any(), any())
+    }
+
+    @Test
+    fun `KST 자정이 지나면 다시 ExPoint를 적립한다`() {
+        val originalMember = member(lastEnter = LocalDateTime.of(2026, 5, 30, 10, 0))
+        val number = originalMember.number!!
+        given(memberRepository.findByNumber(number)).willReturn(originalMember)
+
+        service.createDoorLockAccess(number, 406, LocalDateTime.of(2026, 5, 31, 23, 59))
+
+        val captor = argumentCaptor<Member>()
+        verify(memberRepository).save(captor.capture())
+        val firstAccessMember = captor.firstValue
+        given(memberRepository.findByNumber(number)).willReturn(firstAccessMember)
+
+        service.createDoorLockAccess(number, 406, LocalDateTime.of(2026, 6, 1, 0, 1))
+
+        verify(pointService, org.mockito.kotlin.times(2)).givePoint(originalMember.id, 1, "동방 출입")
+    }
+
+    private fun member(lastEnter: LocalDateTime): Member {
+        return Member(
+            id = 1L,
+            name = "test-user",
+            number = 2026000001L,
+            realname = "홍길동",
+            studentStatus = StudentStatus.UNDERGRADUATE,
+            status = UserStatus.ACTIVE,
+            lastEnter = lastEnter,
+        )
+    }
+}

--- a/src/test/kotlin/com/sight/service/DoorLockAlertServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/DoorLockAlertServiceTest.kt
@@ -1,0 +1,50 @@
+package com.sight.service
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.springframework.http.HttpEntity
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestTemplate
+
+class DoorLockAlertServiceTest {
+    private val restTemplate: RestTemplate = mock()
+
+    @Test
+    fun `alertDie는 디스코드 웹훅으로 알림을 전송한다`() {
+        val webhookUrl = "https://discord.com/api/webhooks/door-lock"
+        val service = DoorLockAlertService(webhookUrl, restTemplate)
+        given(restTemplate.postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java)))
+            .willReturn(ResponseEntity.ok("success"))
+
+        service.alertDie()
+
+        verify(restTemplate).postForEntity(
+            eq(webhookUrl),
+            any<HttpEntity<*>>(),
+            eq(String::class.java),
+        )
+    }
+
+    @Test
+    fun `alertDie는 웹훅 URL이 비어있으면 전송하지 않는다`() {
+        val service = DoorLockAlertService("", restTemplate)
+
+        service.alertDie()
+
+        verify(restTemplate, never()).postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java))
+    }
+
+    @Test
+    fun `alertDie는 웹훅 전송 실패시 예외를 던지지 않는다`() {
+        val service = DoorLockAlertService("https://discord.com/api/webhooks/door-lock", restTemplate)
+        given(restTemplate.postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java)))
+            .willThrow(RuntimeException("Webhook failed"))
+
+        service.alertDie()
+    }
+}

--- a/src/test/kotlin/com/sight/service/DoorLockMemberServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/DoorLockMemberServiceTest.kt
@@ -1,0 +1,61 @@
+package com.sight.service
+
+import com.sight.domain.member.Member
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
+import com.sight.repository.MemberRepository
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import kotlin.test.assertEquals
+
+class DoorLockMemberServiceTest {
+    private val memberRepository = mock<MemberRepository>()
+    private val doorLockMemberService = DoorLockMemberService(memberRepository)
+
+    private fun member(
+        id: Long,
+        realname: String,
+        number: Long?,
+    ): Member =
+        Member(
+            id = id,
+            name = "user$id",
+            realname = realname,
+            number = number,
+            studentStatus = StudentStatus.UNDERGRADUATE,
+            status = UserStatus.ACTIVE,
+        )
+
+    @Test
+    fun `학번이 있는 회원 명단을 반환한다`() {
+        given(memberRepository.findByNumberIsNotNull()).willReturn(
+            listOf(
+                member(1L, "김철수", 2020001L),
+                member(2L, "이영희", 2020002L),
+            ),
+        )
+
+        val result = doorLockMemberService.listDoorLockMembers()
+
+        verify(memberRepository).findByNumberIsNotNull()
+        assertEquals(2, result.size)
+        assertEquals(listOf("김철수", "이영희"), result.map { it.realname })
+    }
+
+    @Test
+    fun `학번이 0인 제명·탈퇴 회원은 명단에서 제외한다`() {
+        given(memberRepository.findByNumberIsNotNull()).willReturn(
+            listOf(
+                member(1L, "김철수", 2020001L),
+                member(2L, "탈퇴회원", 0L),
+            ),
+        )
+
+        val result = doorLockMemberService.listDoorLockMembers()
+
+        assertEquals(1, result.size)
+        assertEquals(2020001L, result.single().number)
+    }
+}


### PR DESCRIPTION
도어락 관련 API를 구현합니다.

- 도어락 회원 명단 조회 (내부 API)
- 동방 출입 보고
- 도어락 데몬 다운(die) 알림

커밋별 구현자: 회원 명단(@SolidCitadel), 출입 보고·die 알림(@parksiwoo2).