### PR TITLE
test: Konsist 아키텍처 계층 테스트 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,10 @@
+import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("org.springframework.boot") version "3.3.5"
     id("io.spring.dependency-management") version "1.1.6"
+    `jvm-test-suite`
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
     kotlin("plugin.jpa") version "1.9.25"
@@ -64,6 +66,27 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+testing {
+    suites {
+        register<JvmTestSuite>("konsistTest") {
+            useJUnitJupiter()
+
+            dependencies {
+                implementation(project())
+                implementation("com.lemonappdev:konsist:0.17.3")
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(tasks.test)
+                    }
+                }
+            }
+        }
+    }
 }
 
 ktlint {

--- a/src/konsistTest/kotlin/com/sight/ArchitectureLayerTest.kt
+++ b/src/konsistTest/kotlin/com/sight/ArchitectureLayerTest.kt
@@ -1,0 +1,48 @@
+package com.sight
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator
+import com.lemonappdev.konsist.api.architecture.Layer
+import org.junit.jupiter.api.Test
+
+class ArchitectureLayerTest {
+    @Test
+    fun `프로젝트 계층 의존성 방향을 강제한다`() {
+        with(KoArchitectureCreator) {
+            Konsist.scopeFromProject().assertArchitecture {
+                val controllers = Layer("controllers", "com.sight.controllers..")
+                val service = Layer("service", "com.sight.service..")
+                val domain = Layer("domain", "com.sight.domain..")
+                val config = Layer("config", "com.sight.config..")
+                val core = Layer("core", "com.sight.core..")
+                val repository = Layer("repository", "com.sight.repository..")
+
+                controllers.dependsOn(service)
+                controllers.dependsOn(config)
+                controllers.dependsOn(core)
+                controllers.dependsOn(repository)
+
+                service.dependsOn(domain)
+                service.dependsOn(config)
+                service.dependsOn(core)
+                service.dependsOn(repository)
+
+                domain.dependsOn(config)
+                domain.dependsOn(core)
+                domain.dependsOn(repository)
+
+                config.doesNotDependOn(controllers)
+                config.doesNotDependOn(service)
+                config.doesNotDependOn(domain)
+
+                core.doesNotDependOn(controllers)
+                core.doesNotDependOn(service)
+                core.doesNotDependOn(domain)
+
+                repository.doesNotDependOn(controllers)
+                repository.doesNotDependOn(service)
+                repository.doesNotDependOn(domain)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- 별도 konsistTest JVM 테스트 스위트를 추가했습니다.
- 아키텍처 테스트를 위한 Konsist 의존성을 추가했습니다.
- 프로젝트 계층 의존성 방향 규칙을 정의하되, 기본 test/check 흐름에는 연결하지 않았습니다.

## 검증
- ./gradlew compileKonsistTestKotlin
- ./gradlew ktlintCheck