### PR TITLE
test: Konsist 검사 범위를 main source로 제한

### DIFF
--- a/src/konsistTest/kotlin/com/sight/ArchitectureLayerTest.kt
+++ b/src/konsistTest/kotlin/com/sight/ArchitectureLayerTest.kt
@@ -9,7 +9,7 @@ class ArchitectureLayerTest {
     @Test
     fun `프로젝트 계층 의존성 방향을 강제한다`() {
         with(KoArchitectureCreator) {
-            Konsist.scopeFromProject().assertArchitecture {
+            Konsist.scopeFromDirectory("src/main/kotlin").assertArchitecture {
                 val controllers = Layer("controllers", "com.sight.controllers..")
                 val service = Layer("service", "com.sight.service..")
                 val domain = Layer("domain", "com.sight.domain..")


### PR DESCRIPTION
## 요약
- Konsist 계층 테스트의 검사 범위를 프로젝트 전체에서 src/main/kotlin으로 제한했습니다.
- 테스트 코드와 빌드 산출물(bin)이 layer test에 포함되어 중복으로 위반이 잡히는 문제를 줄였습니다.

## 검증
- ./gradlew compileKonsistTestKotlin
- ./gradlew ktlintCheck
- ./gradlew konsistTest: 기존 production 계층 위반으로 실패하지만, 리포트 대상은 src/main/kotlin으로 제한됨을 확인했습니다.