### PR TITLE
test: 계층 테스트에서 금지 의존성만 검증

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker build -f Dockerfile.Build -t sight-spring-backend .
 ### 의존성 방향
 - 일반적인 로직 처리 흐름: `controllers` → `service` → `domain`
 - 역방향 의존성은 금지
-- `config`, `core`, `repository`는 다른 계층에서 접근 가능하지만 역방향은 불가
+- `config`, `core`는 다른 계층에서 접근 가능하지만 역방향은 불가
 
 ```mermaid
 graph TD
@@ -86,6 +86,8 @@ graph TD
     Domain --> Config
     Domain --> Core
     Domain --> Repository
+
+    Repository --> Domain
     
     style Controllers fill:#e1f5fe
     style Service fill:#f3e5f5

--- a/src/konsistTest/kotlin/com/sight/ArchitectureLayerTest.kt
+++ b/src/konsistTest/kotlin/com/sight/ArchitectureLayerTest.kt
@@ -17,19 +17,10 @@ class ArchitectureLayerTest {
                 val core = Layer("core", "com.sight.core..")
                 val repository = Layer("repository", "com.sight.repository..")
 
-                controllers.dependsOn(service)
-                controllers.dependsOn(config)
-                controllers.dependsOn(core)
-                controllers.dependsOn(repository)
+                service.doesNotDependOn(controllers)
 
-                service.dependsOn(domain)
-                service.dependsOn(config)
-                service.dependsOn(core)
-                service.dependsOn(repository)
-
-                domain.dependsOn(config)
-                domain.dependsOn(core)
-                domain.dependsOn(repository)
+                domain.doesNotDependOn(controllers)
+                domain.doesNotDependOn(service)
 
                 config.doesNotDependOn(controllers)
                 config.doesNotDependOn(service)
@@ -41,7 +32,6 @@ class ArchitectureLayerTest {
 
                 repository.doesNotDependOn(controllers)
                 repository.doesNotDependOn(service)
-                repository.doesNotDependOn(domain)
             }
         }
     }


### PR DESCRIPTION
## 요약
- Konsist 계층 테스트에서 필수 의존성을 강제하던 dependsOn 규칙을 제거했습니다.
- controllers -> service -> domain 흐름의 역방향 의존성을 금지하는 규칙을 추가했습니다.
- repository -> domain 의존은 허용되도록 테스트와 README 의존성 방향을 정리했습니다.

## 검증
- ./gradlew compileKonsistTestKotlin
- ./gradlew ktlintCheck
- ./gradlew konsistTest: 기존 production 계층 위반(service -> controllers, config -> controllers, core -> controllers, core -> service)으로 실패함을 확인했습니다.