### PR TITLE
refactor: 서비스의 컨트롤러 DTO 의존 제거

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/KhlugPhoneController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/KhlugPhoneController.kt
@@ -20,7 +20,10 @@ class KhlugPhoneController(
     fun reportPhoneStatus(
         @Valid @RequestBody request: ReportPhoneStatusRequest,
     ): ResponseEntity<Void> {
-        khlugPhoneService.reportPhoneStatus(request)
+        khlugPhoneService.reportPhoneStatus(
+            batteryPercent = request.batteryPercent,
+            batteryStatus = request.batteryStatus,
+        )
         return ResponseEntity.noContent().build()
     }
 
@@ -29,7 +32,12 @@ class KhlugPhoneController(
     fun forwardNotification(
         @Valid @RequestBody request: ForwardNotificationRequest,
     ): ResponseEntity<Void> {
-        khlugPhoneService.forwardNotification(request)
+        khlugPhoneService.forwardNotification(
+            appName = request.appName,
+            title = request.title,
+            content = request.content,
+            receivedAt = request.receivedAt,
+        )
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/sight/controllers/http/TransactionController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/TransactionController.kt
@@ -86,7 +86,13 @@ class TransactionController(
     ): CreateTransactionResponse {
         val transaction =
             transactionService.createTransaction(
-                request = request,
+                type = request.type,
+                item = request.item,
+                price = request.price,
+                quantity = request.quantity,
+                place = request.place,
+                note = request.note,
+                usedAt = request.usedAt,
                 authorId = requester.userId,
             )
 

--- a/src/main/kotlin/com/sight/service/KhlugPhoneService.kt
+++ b/src/main/kotlin/com/sight/service/KhlugPhoneService.kt
@@ -1,7 +1,5 @@
 package com.sight.service
 
-import com.sight.controllers.http.dto.ForwardNotificationRequest
-import com.sight.controllers.http.dto.ReportPhoneStatusRequest
 import com.sight.domain.device.BatteryStatus
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -22,22 +20,30 @@ class KhlugPhoneService(
 ) {
     private val logger = LoggerFactory.getLogger(KhlugPhoneService::class.java)
 
-    fun reportPhoneStatus(request: ReportPhoneStatusRequest) {
-        if (request.batteryPercent > 20 || request.batteryStatus == BatteryStatus.CHARGING) {
+    fun reportPhoneStatus(
+        batteryPercent: Int,
+        batteryStatus: BatteryStatus,
+    ) {
+        if (batteryPercent > 20 || batteryStatus == BatteryStatus.CHARGING) {
             return
         }
 
         try {
-            val payload = createDiscordWebhookPayload(request)
+            val payload = createDiscordWebhookPayload(batteryPercent, batteryStatus)
             sendWebhook(payload)
         } catch (e: Exception) {
             logger.error("쿠러그 폰 상태 알림 전송 실패", e)
         }
     }
 
-    fun forwardNotification(request: ForwardNotificationRequest) {
+    fun forwardNotification(
+        appName: String,
+        title: String,
+        content: String,
+        receivedAt: Instant,
+    ) {
         try {
-            val payload = createNotificationWebhookPayload(request)
+            val payload = createNotificationWebhookPayload(appName, title, content, receivedAt)
             sendWebhook(payload)
         } catch (e: Exception) {
             logger.error("푸시 알림 포워딩 실패", e)
@@ -59,45 +65,53 @@ class KhlugPhoneService(
         restTemplate.postForEntity(webhookUrl, httpEntity, String::class.java)
     }
 
-    private fun createNotificationWebhookPayload(request: ForwardNotificationRequest): Map<String, Any> {
+    private fun createNotificationWebhookPayload(
+        appName: String,
+        title: String,
+        content: String,
+        receivedAt: Instant,
+    ): Map<String, Any> {
         val description =
             listOf(
-                "**${request.title}**",
-                request.content,
+                "**$title**",
+                content,
             ).joinToString("\n")
 
         val embed =
             mapOf(
-                "title" to "📱 ${request.appName} 알림",
+                "title" to "📱 $appName 알림",
                 "description" to description,
                 "color" to 0x3498DB,
-                "timestamp" to request.receivedAt.toString(),
+                "timestamp" to receivedAt.toString(),
             )
 
         return mapOf("embeds" to listOf(embed))
     }
 
-    private fun createDiscordWebhookPayload(request: ReportPhoneStatusRequest): Map<String, Any> {
+    private fun createDiscordWebhookPayload(
+        batteryPercent: Int,
+        batteryStatus: BatteryStatus,
+    ): Map<String, Any> {
         val color =
             when {
                 // Red
-                request.batteryPercent <= 20 -> 0xE74C3C
+                batteryPercent <= 20 -> 0xE74C3C
 
                 // Orange
-                request.batteryPercent <= 50 -> 0xF39C12
+                batteryPercent <= 50 -> 0xF39C12
 
                 // Green
                 else -> 0x2ECC71
             }
 
         val statusEmoji =
-            when (request.batteryStatus) {
+            when (batteryStatus) {
                 BatteryStatus.CHARGING -> "🔌"
                 BatteryStatus.NOT_CHARGING -> "🔋"
             }
 
         val statusText =
-            when (request.batteryStatus) {
+            when (batteryStatus) {
                 BatteryStatus.CHARGING -> "충전 중"
                 BatteryStatus.NOT_CHARGING -> "충전 안 함"
             }
@@ -105,7 +119,7 @@ class KhlugPhoneService(
         val batterySection =
             listOf(
                 "**🔋 배터리**",
-                "$statusEmoji **${request.batteryPercent}%** - $statusText",
+                "$statusEmoji **$batteryPercent%** - $statusText",
             ).joinToString("\n")
 
         val embed =

--- a/src/main/kotlin/com/sight/service/TransactionService.kt
+++ b/src/main/kotlin/com/sight/service/TransactionService.kt
@@ -1,7 +1,6 @@
 package com.sight.service
 
 import com.github.f4b6a3.ulid.UlidCreator
-import com.sight.controllers.http.dto.CreateTransactionRequest
 import com.sight.core.exception.NotFoundException
 import com.sight.core.exception.UnprocessableEntityException
 import com.sight.domain.finance.Transaction
@@ -96,20 +95,26 @@ class TransactionService(
 
     @Transactional
     fun createTransaction(
-        request: CreateTransactionRequest,
+        type: TransactionType,
+        item: String,
+        price: Long,
+        quantity: Long,
+        place: String?,
+        note: String?,
+        usedAt: LocalDate,
         authorId: Long,
     ): Transaction {
         val today = LocalDate.now()
-        if (request.usedAt.isAfter(today)) {
+        if (usedAt.isAfter(today)) {
             throw UnprocessableEntityException("미래 날짜는 입력할 수 없습니다")
         }
 
-        val total = request.price * request.quantity
+        val total = price * quantity
 
         // 추가하려는 날짜이거나 이보다 이전의 장부 내역 조회
-        val prevCumulative = transactionRepository.findLatestOnOrBefore(request.usedAt)?.cumulative ?: 0L
+        val prevCumulative = transactionRepository.findLatestOnOrBefore(usedAt)?.cumulative ?: 0L
         val cumulative =
-            when (request.type) {
+            when (type) {
                 TransactionType.INCOME -> prevCumulative + total
                 TransactionType.EXPENSE -> prevCumulative - total
             }
@@ -118,22 +123,22 @@ class TransactionService(
             Transaction(
                 id = UlidCreator.getUlid().toString(),
                 author = authorId,
-                type = request.type,
-                item = request.item,
-                price = request.price,
-                quantity = request.quantity,
+                type = type,
+                item = item,
+                price = price,
+                quantity = quantity,
                 total = total,
                 cumulative = cumulative,
-                place = request.place,
-                note = request.note,
-                usedAt = request.usedAt,
+                place = place,
+                note = note,
+                usedAt = usedAt,
             )
 
         val saved = transactionRepository.save(transaction)
 
         // 추가하려는 날짜 위치보다 미래 날짜에 있는 모든 항목들
         // 동일 `usedAt` 값 기준으로 항상 지금 생성되는 장부 내역의 `createdAt`이 가장 클 것이므로 미래 날짜만 조회하면 됨.
-        val successors = transactionRepository.findAfterDate(request.usedAt)
+        val successors = transactionRepository.findAfterDate(usedAt)
         if (successors.isNotEmpty()) {
             var runningCumulative = cumulative
             val updated =

--- a/src/test/kotlin/com/sight/service/KhlugPhoneServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/KhlugPhoneServiceTest.kt
@@ -1,7 +1,5 @@
 package com.sight.service
 
-import com.sight.controllers.http.dto.ForwardNotificationRequest
-import com.sight.controllers.http.dto.ReportPhoneStatusRequest
 import com.sight.domain.device.BatteryStatus
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -32,16 +30,14 @@ class KhlugPhoneServiceTest {
     @Test
     fun `reportPhoneStatus는 배터리 20% 이하이고 충전 중이 아닐 때 웹훅을 호출한다`() {
         // given
-        val request =
-            ReportPhoneStatusRequest(
-                batteryPercent = 20,
-                batteryStatus = BatteryStatus.NOT_CHARGING,
-            )
         given(restTemplate.postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java)))
             .willReturn(ResponseEntity.ok("success"))
 
         // when
-        service.reportPhoneStatus(request)
+        service.reportPhoneStatus(
+            batteryPercent = 20,
+            batteryStatus = BatteryStatus.NOT_CHARGING,
+        )
 
         // then
         verify(restTemplate).postForEntity(
@@ -54,14 +50,11 @@ class KhlugPhoneServiceTest {
     @Test
     fun `reportPhoneStatus는 배터리 20% 초과이면 웹훅을 호출하지 않는다`() {
         // given
-        val request =
-            ReportPhoneStatusRequest(
-                batteryPercent = 21,
-                batteryStatus = BatteryStatus.NOT_CHARGING,
-            )
-
         // when
-        service.reportPhoneStatus(request)
+        service.reportPhoneStatus(
+            batteryPercent = 21,
+            batteryStatus = BatteryStatus.NOT_CHARGING,
+        )
 
         // then
         verify(restTemplate, never()).postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java))
@@ -70,14 +63,11 @@ class KhlugPhoneServiceTest {
     @Test
     fun `reportPhoneStatus는 충전 중이면 웹훅을 호출하지 않는다`() {
         // given
-        val request =
-            ReportPhoneStatusRequest(
-                batteryPercent = 10,
-                batteryStatus = BatteryStatus.CHARGING,
-            )
-
         // when
-        service.reportPhoneStatus(request)
+        service.reportPhoneStatus(
+            batteryPercent = 10,
+            batteryStatus = BatteryStatus.CHARGING,
+        )
 
         // then
         verify(restTemplate, never()).postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java))
@@ -86,16 +76,14 @@ class KhlugPhoneServiceTest {
     @Test
     fun `reportPhoneStatus는 웹훅 실패시 예외를 던지지 않는다`() {
         // given
-        val request =
-            ReportPhoneStatusRequest(
-                batteryPercent = 20,
-                batteryStatus = BatteryStatus.NOT_CHARGING,
-            )
         given(restTemplate.postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java)))
             .willThrow(RuntimeException("Webhook failed"))
 
         // when & then (예외가 발생하지 않으면 성공)
-        service.reportPhoneStatus(request)
+        service.reportPhoneStatus(
+            batteryPercent = 20,
+            batteryStatus = BatteryStatus.NOT_CHARGING,
+        )
     }
 
     @Test
@@ -106,14 +94,12 @@ class KhlugPhoneServiceTest {
                 webhookUrl = "",
                 restTemplate = restTemplate,
             )
-        val request =
-            ReportPhoneStatusRequest(
-                batteryPercent = 15,
-                batteryStatus = BatteryStatus.NOT_CHARGING,
-            )
 
         // when
-        emptyWebhookService.reportPhoneStatus(request)
+        emptyWebhookService.reportPhoneStatus(
+            batteryPercent = 15,
+            batteryStatus = BatteryStatus.NOT_CHARGING,
+        )
 
         // then
         verify(restTemplate, never()).postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java))
@@ -122,18 +108,16 @@ class KhlugPhoneServiceTest {
     @Test
     fun `forwardNotification은 웹훅을 호출한다`() {
         // given
-        val request =
-            ForwardNotificationRequest(
-                appName = "카카오톡",
-                title = "홍길동",
-                content = "안녕하세요",
-                receivedAt = Instant.parse("2024-01-01T12:00:00Z"),
-            )
         given(restTemplate.postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java)))
             .willReturn(ResponseEntity.ok("success"))
 
         // when
-        service.forwardNotification(request)
+        service.forwardNotification(
+            appName = "카카오톡",
+            title = "홍길동",
+            content = "안녕하세요",
+            receivedAt = Instant.parse("2024-01-01T12:00:00Z"),
+        )
 
         // then
         verify(restTemplate).postForEntity(
@@ -151,16 +135,14 @@ class KhlugPhoneServiceTest {
                 webhookUrl = "",
                 restTemplate = restTemplate,
             )
-        val request =
-            ForwardNotificationRequest(
-                appName = "카카오톡",
-                title = "홍길동",
-                content = "안녕하세요",
-                receivedAt = Instant.parse("2024-01-01T12:00:00Z"),
-            )
 
         // when
-        emptyWebhookService.forwardNotification(request)
+        emptyWebhookService.forwardNotification(
+            appName = "카카오톡",
+            title = "홍길동",
+            content = "안녕하세요",
+            receivedAt = Instant.parse("2024-01-01T12:00:00Z"),
+        )
 
         // then
         verify(restTemplate, never()).postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java))
@@ -169,17 +151,15 @@ class KhlugPhoneServiceTest {
     @Test
     fun `forwardNotification은 웹훅 실패시 예외를 던지지 않는다`() {
         // given
-        val request =
-            ForwardNotificationRequest(
-                appName = "카카오톡",
-                title = "홍길동",
-                content = "안녕하세요",
-                receivedAt = Instant.parse("2024-01-01T12:00:00Z"),
-            )
         given(restTemplate.postForEntity(any<String>(), any<HttpEntity<*>>(), eq(String::class.java)))
             .willThrow(RuntimeException("Webhook failed"))
 
         // when & then (예외가 발생하지 않으면 성공)
-        service.forwardNotification(request)
+        service.forwardNotification(
+            appName = "카카오톡",
+            title = "홍길동",
+            content = "안녕하세요",
+            receivedAt = Instant.parse("2024-01-01T12:00:00Z"),
+        )
     }
 }

--- a/src/test/kotlin/com/sight/service/TransactionServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/TransactionServiceTest.kt
@@ -1,6 +1,5 @@
 package com.sight.service
 
-import com.sight.controllers.http.dto.CreateTransactionRequest
 import com.sight.core.exception.NotFoundException
 import com.sight.core.exception.UnprocessableEntityException
 import com.sight.domain.finance.Transaction
@@ -103,25 +102,26 @@ class TransactionServiceTest {
     fun `createTransaction은 이전 거래가 없을 때 cumulative를 total과 같게 설정한다`() {
         // given
         val authorId = 1L
-        val request =
-            CreateTransactionRequest(
+        val usedAt = LocalDate.of(2024, 1, 15)
+
+        given(transactionRepository.findLatestOnOrBefore(usedAt)).willReturn(null)
+        given(transactionRepository.save(any<Transaction>())).willAnswer {
+            it.arguments[0] as Transaction
+        }
+        given(transactionRepository.findAfterDate(usedAt)).willReturn(emptyList())
+
+        // when
+        val result =
+            transactionService.createTransaction(
                 type = TransactionType.INCOME,
                 item = "테스트 항목",
                 price = 10000L,
                 quantity = 2L,
                 place = "테스트 장소",
                 note = "테스트 노트",
-                usedAt = LocalDate.of(2024, 1, 15),
+                usedAt = usedAt,
+                authorId = authorId,
             )
-
-        given(transactionRepository.findLatestOnOrBefore(request.usedAt)).willReturn(null)
-        given(transactionRepository.save(any<Transaction>())).willAnswer {
-            it.arguments[0] as Transaction
-        }
-        given(transactionRepository.findAfterDate(request.usedAt)).willReturn(emptyList())
-
-        // when
-        val result = transactionService.createTransaction(request, authorId)
 
         // then
         assertEquals(20000L, result.total) // 10000 * 2
@@ -132,16 +132,7 @@ class TransactionServiceTest {
     fun `createTransaction은 이전 거래가 있을 때 cumulative를 누적한다`() {
         // given
         val authorId = 1L
-        val request =
-            CreateTransactionRequest(
-                type = TransactionType.INCOME,
-                item = "테스트 항목",
-                price = 5000L,
-                quantity = 1L,
-                place = null,
-                note = null,
-                usedAt = LocalDate.of(2024, 1, 20),
-            )
+        val usedAt = LocalDate.of(2024, 1, 20)
 
         val previousTransaction =
             Transaction(
@@ -160,14 +151,24 @@ class TransactionServiceTest {
                 updatedAt = LocalDateTime.now(),
             )
 
-        given(transactionRepository.findLatestOnOrBefore(request.usedAt)).willReturn(previousTransaction)
+        given(transactionRepository.findLatestOnOrBefore(usedAt)).willReturn(previousTransaction)
         given(transactionRepository.save(any<Transaction>())).willAnswer {
             it.arguments[0] as Transaction
         }
-        given(transactionRepository.findAfterDate(request.usedAt)).willReturn(emptyList())
+        given(transactionRepository.findAfterDate(usedAt)).willReturn(emptyList())
 
         // when
-        val result = transactionService.createTransaction(request, authorId)
+        val result =
+            transactionService.createTransaction(
+                type = TransactionType.INCOME,
+                item = "테스트 항목",
+                price = 5000L,
+                quantity = 1L,
+                place = null,
+                note = null,
+                usedAt = usedAt,
+                authorId = authorId,
+            )
 
         // then
         assertEquals(5000L, result.total) // 5000 * 1
@@ -179,16 +180,7 @@ class TransactionServiceTest {
         // given
         val authorId = 1L
         val currentPrice = 5000L
-        val request =
-            CreateTransactionRequest(
-                type = TransactionType.EXPENSE,
-                item = "테스트 항목",
-                price = currentPrice,
-                quantity = 1L,
-                place = null,
-                note = null,
-                usedAt = LocalDate.of(2024, 1, 20),
-            )
+        val usedAt = LocalDate.of(2024, 1, 20)
 
         val previousTransaction =
             Transaction(
@@ -207,14 +199,24 @@ class TransactionServiceTest {
                 updatedAt = LocalDateTime.now(),
             )
 
-        given(transactionRepository.findLatestOnOrBefore(request.usedAt)).willReturn(previousTransaction)
+        given(transactionRepository.findLatestOnOrBefore(usedAt)).willReturn(previousTransaction)
         given(transactionRepository.save(any<Transaction>())).willAnswer {
             it.arguments[0] as Transaction
         }
-        given(transactionRepository.findAfterDate(request.usedAt)).willReturn(emptyList())
+        given(transactionRepository.findAfterDate(usedAt)).willReturn(emptyList())
 
         // when
-        val result = transactionService.createTransaction(request, authorId)
+        val result =
+            transactionService.createTransaction(
+                type = TransactionType.EXPENSE,
+                item = "테스트 항목",
+                price = currentPrice,
+                quantity = 1L,
+                place = null,
+                note = null,
+                usedAt = usedAt,
+                authorId = authorId,
+            )
 
         // then
         assertEquals(currentPrice, result.total) // 5000 * 1
@@ -225,20 +227,20 @@ class TransactionServiceTest {
     fun `createTransaction은 미래 날짜 입력 시 예외를 던진다`() {
         // given
         val authorId = 1L
-        val request =
-            CreateTransactionRequest(
+        val usedAt = LocalDate.now().plusDays(1)
+
+        // when & then
+        assertThrows<UnprocessableEntityException> {
+            transactionService.createTransaction(
                 type = TransactionType.EXPENSE,
                 item = "테스트",
                 price = 1000L,
                 quantity = 1L,
                 place = null,
                 note = null,
-                usedAt = LocalDate.now().plusDays(1),
+                usedAt = usedAt,
+                authorId = authorId,
             )
-
-        // when & then
-        assertThrows<UnprocessableEntityException> {
-            transactionService.createTransaction(request, authorId)
         }
     }
 }


### PR DESCRIPTION
## 요약
- KhlugPhoneService와 TransactionService가 controller DTO 대신 명시 파라미터를 받도록 변경했습니다.
- 컨트롤러에서 request DTO 값을 풀어 서비스에 전달하도록 수정했습니다.
- 서비스 테스트에서 controller DTO import를 제거하고 새 서비스 시그니처에 맞췄습니다.

## 검증
- ./gradlew compileKotlin
- ./gradlew test
- ./gradlew ktlintCheck
- ./gradlew konsistTest: service -> controllers 위반은 해소됐고, 기존 config/core 관련 위반은 남아 있습니다.