### PR TITLE
refactor: 오류 응답 DTO를 core 계층으로 이동

### DIFF
--- a/src/main/kotlin/com/sight/config/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/sight/config/CustomAccessDeniedHandler.kt
@@ -1,7 +1,7 @@
 package com.sight.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.sight.controllers.http.dto.ErrorResponse
+import com.sight.core.response.ErrorResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/sight/config/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/sight/config/CustomAuthenticationEntryPoint.kt
@@ -1,7 +1,7 @@
 package com.sight.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.sight.controllers.http.dto.ErrorResponse
+import com.sight.core.response.ErrorResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/sight/core/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/sight/core/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,6 @@
 package com.sight.core.exception
 
-import com.sight.controllers.http.dto.ErrorResponse
+import com.sight.core.response.ErrorResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException

--- a/src/main/kotlin/com/sight/core/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/sight/core/response/ErrorResponse.kt
@@ -1,4 +1,4 @@
-package com.sight.controllers.http.dto
+package com.sight.core.response
 
 data class ErrorResponse(
     val statusCode: Int,


### PR DESCRIPTION
## 변경 사항
- ErrorResponse를 controllers.http.dto에서 core.response로 이동했습니다.
- 전역 예외 처리와 인증/인가 실패 핸들러가 새 ErrorResponse 위치를 참조하도록 수정했습니다.

## 확인 사항
- ./gradlew compileKotlin 통과
- ./gradlew konsistTest 실행 시 ErrorResponse 관련 계층 위반은 해소됐고, 기존 core.discord.UserDiscordEventHandler의 service.UserService 의존 위반만 남아 있습니다.