### PR TITLE
test: 계층 의존성 계약 강화

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/GroupController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupController.kt
@@ -11,7 +11,6 @@ import com.sight.controllers.http.dto.PublishPortfolioResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
-import com.sight.domain.group.GroupOrderBy
 import com.sight.service.GroupDiscordChannelService
 import com.sight.service.GroupService
 import jakarta.validation.Valid
@@ -44,11 +43,11 @@ class GroupController(
         @RequestParam(required = false) state: String?,
         @RequestParam(required = false) interest: String?,
         @RequestParam(required = false) keyword: String?,
-        @RequestParam(required = false) orderBy: GroupOrderBy?,
+        @RequestParam(required = false) orderBy: String?,
         requester: Requester,
     ): ListGroupsResponse {
         val result =
-            groupService.listGroups(
+            groupService.listGroupsByQuery(
                 offset = offset,
                 limit = limit,
                 bookmarked = bookmarked,

--- a/src/main/kotlin/com/sight/controllers/http/GroupMatchingAnswerController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupMatchingAnswerController.kt
@@ -8,7 +8,6 @@ import com.sight.controllers.http.dto.GetAnswersResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
-import com.sight.domain.groupmatching.GroupMatchingType
 import com.sight.service.GroupMatchingAnswerService
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
@@ -75,7 +74,7 @@ class GroupMatchingAnswerController(
     @GetMapping("/group-matchings/{groupMatchingId}/answers")
     fun getAnswers(
         @PathVariable groupMatchingId: String,
-        @RequestParam(required = false) groupType: GroupMatchingType?,
+        @RequestParam(required = false) groupType: String?,
         @RequestParam(required = false) optionId: String?,
         @RequestParam(required = false, defaultValue = "0")
         @Min(0, message = "offset은 0 이상이어야 합니다")
@@ -84,7 +83,7 @@ class GroupMatchingAnswerController(
         @Min(1, message = "limit은 양의 정수여야 합니다")
         limit: Int,
     ): GetAnswersResponse {
-        val result = groupMatchingAnswerService.listAnswers(groupMatchingId, groupType, optionId, offset, limit)
+        val result = groupMatchingAnswerService.listAnswersByQuery(groupMatchingId, groupType, optionId, offset, limit)
 
         return GetAnswersResponse(
             answers =

--- a/src/main/kotlin/com/sight/controllers/http/GroupMatchingController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupMatchingController.kt
@@ -13,7 +13,6 @@ import com.sight.controllers.http.dto.UpdateGroupMatchingClosedAtRequest
 import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
-import com.sight.domain.groupmatching.GroupMatchingType
 import com.sight.service.GroupMatchingService
 import com.sight.service.dto.UpdateGroupMatchingAnswerDto
 import jakarta.validation.Valid
@@ -36,9 +35,9 @@ class GroupMatchingController(
     @GetMapping("/group-matchings/{groupMatchingId}/groups")
     fun getGroups(
         @PathVariable groupMatchingId: String,
-        @RequestParam(required = false) groupType: GroupMatchingType?,
+        @RequestParam(required = false) groupType: String?,
     ): List<GetGroupMatchingGroupsResponse> {
-        return groupMatchingService.getGroups(groupMatchingId, groupType).map { groupDto ->
+        return groupMatchingService.getGroupsByQuery(groupMatchingId, groupType).map { groupDto ->
             GetGroupMatchingGroupsResponse(
                 id = groupDto.id,
                 title = groupDto.title,

--- a/src/main/kotlin/com/sight/controllers/http/GroupMatchingOptionController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/GroupMatchingOptionController.kt
@@ -3,7 +3,6 @@ package com.sight.controllers.http
 import com.sight.controllers.http.dto.ListGroupMatchingOptionsResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.UserRole
-import com.sight.domain.groupmatching.GroupMatchingType
 import com.sight.service.GroupMatchingOptionService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,9 +17,9 @@ class GroupMatchingOptionController(
     @GetMapping("/group-matchings/{groupMatchingId}/options")
     fun listOptions(
         @PathVariable groupMatchingId: String,
-        @RequestParam type: GroupMatchingType,
+        @RequestParam type: String,
     ): List<ListGroupMatchingOptionsResponse> {
-        val options = groupMatchingOptionService.listOptions(groupMatchingId, type)
+        val options = groupMatchingOptionService.listOptionsByQuery(groupMatchingId, type)
         return options.map { option ->
             ListGroupMatchingOptionsResponse(
                 id = option.id,

--- a/src/main/kotlin/com/sight/controllers/http/UserRegistrationRequestController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/UserRegistrationRequestController.kt
@@ -8,7 +8,6 @@ import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
 import com.sight.core.exception.BadRequestException
-import com.sight.domain.application.UserRegistrationRequestStatus
 import com.sight.service.UserRegistrationRequestService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -29,12 +28,7 @@ class UserRegistrationRequestController(
         @PathVariable requestId: String,
         @Valid @RequestBody request: UpdateUserRegistrationRequestStatusRequest,
     ): UpdateUserRegistrationRequestStatusResponse {
-        val status =
-            UserRegistrationRequestStatus.entries.find {
-                it.name.equals(request.status, ignoreCase = true)
-            } ?: throw BadRequestException("지원하지 않는 회원 등록 요청 상태입니다")
-
-        if (status != UserRegistrationRequestStatus.APPROVED) {
+        if (!request.status.equals("APPROVED", ignoreCase = true)) {
             throw BadRequestException("지원하지 않는 회원 등록 요청 상태입니다")
         }
 

--- a/src/main/kotlin/com/sight/service/GroupMatchingAnswerService.kt
+++ b/src/main/kotlin/com/sight/service/GroupMatchingAnswerService.kt
@@ -108,6 +108,22 @@ class GroupMatchingAnswerService(
     }
 
     @Transactional(readOnly = true)
+    fun listAnswersByQuery(
+        groupMatchingId: String,
+        groupType: String? = null,
+        optionId: String? = null,
+        offset: Int,
+        limit: Int,
+    ): ListAnswersResult =
+        listAnswers(
+            groupMatchingId = groupMatchingId,
+            groupType = groupType?.toGroupMatchingType(),
+            optionId = optionId,
+            offset = offset,
+            limit = limit,
+        )
+
+    @Transactional(readOnly = true)
     fun listAnswers(
         groupMatchingId: String,
         groupType: GroupMatchingType? = null,
@@ -206,3 +222,7 @@ class GroupMatchingAnswerService(
         }
     }
 }
+
+private fun String.toGroupMatchingType(): GroupMatchingType =
+    runCatching { GroupMatchingType.valueOf(this.uppercase()) }
+        .getOrElse { throw BadRequestException("유효하지 않은 그룹 매칭 유형입니다: $this") }

--- a/src/main/kotlin/com/sight/service/GroupMatchingOptionService.kt
+++ b/src/main/kotlin/com/sight/service/GroupMatchingOptionService.kt
@@ -1,5 +1,6 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.NotFoundException
 import com.sight.domain.groupmatching.GroupMatchingOption
 import com.sight.domain.groupmatching.GroupMatchingType
@@ -14,6 +15,12 @@ class GroupMatchingOptionService(
     private val groupMatchingRepository: GroupMatchingRepository,
 ) {
     @Transactional(readOnly = true)
+    fun listOptionsByQuery(
+        groupMatchingId: String,
+        type: String,
+    ): List<GroupMatchingOption> = listOptions(groupMatchingId, type.toGroupMatchingType())
+
+    @Transactional(readOnly = true)
     fun listOptions(
         groupMatchingId: String,
         type: GroupMatchingType,
@@ -27,3 +34,7 @@ class GroupMatchingOptionService(
         )
     }
 }
+
+private fun String.toGroupMatchingType(): GroupMatchingType =
+    runCatching { GroupMatchingType.valueOf(this.uppercase()) }
+        .getOrElse { throw BadRequestException("유효하지 않은 그룹 매칭 유형입니다: $this") }

--- a/src/main/kotlin/com/sight/service/GroupMatchingService.kt
+++ b/src/main/kotlin/com/sight/service/GroupMatchingService.kt
@@ -47,6 +47,12 @@ class GroupMatchingService(
     private val groupMatchingRepository: GroupMatchingRepository,
 ) {
     @Transactional(readOnly = true)
+    fun getGroupsByQuery(
+        groupMatchingId: String,
+        groupType: String?,
+    ): List<GroupMatchingGroupDto> = getGroups(groupMatchingId, groupType?.toGroupMatchingType())
+
+    @Transactional(readOnly = true)
     fun getGroups(
         groupMatchingId: String,
         groupType: GroupMatchingType?,
@@ -393,3 +399,7 @@ class GroupMatchingService(
         val KST: ZoneId = ZoneId.of("Asia/Seoul")
     }
 }
+
+private fun String.toGroupMatchingType(): GroupMatchingType =
+    runCatching { GroupMatchingType.valueOf(this.uppercase()) }
+        .getOrElse { throw BadRequestException("유효하지 않은 그룹 매칭 유형입니다: $this") }

--- a/src/main/kotlin/com/sight/service/GroupService.kt
+++ b/src/main/kotlin/com/sight/service/GroupService.kt
@@ -48,6 +48,39 @@ class GroupService(
     private val notificationService: NotificationService,
 ) {
     @Transactional(readOnly = true)
+    fun listGroupsByQuery(
+        offset: Int,
+        limit: Int,
+        bookmarked: Boolean?,
+        joined: Boolean?,
+        categories: List<String>?,
+        state: String?,
+        interest: String?,
+        keyword: String?,
+        orderBy: String?,
+        requesterId: Long,
+    ): GroupListResult {
+        val validOrderBy =
+            orderBy?.let { value ->
+                GroupOrderBy.fromValue(value)
+                    ?: throw BadRequestException("유효하지 않은 정렬 기준입니다: $value")
+            }
+
+        return listGroups(
+            offset = offset,
+            limit = limit,
+            bookmarked = bookmarked,
+            joined = joined,
+            categories = categories,
+            state = state,
+            interest = interest,
+            keyword = keyword,
+            orderBy = validOrderBy,
+            requesterId = requesterId,
+        )
+    }
+
+    @Transactional(readOnly = true)
     fun listGroups(
         offset: Int,
         limit: Int,

--- a/src/test/kotlin/com/sight/ArchitectureLayerTest.kt
+++ b/src/test/kotlin/com/sight/ArchitectureLayerTest.kt
@@ -4,6 +4,7 @@ import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator
 import com.lemonappdev.konsist.api.architecture.Layer
 import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
 
 class ArchitectureLayerTest {
     @Test
@@ -34,5 +35,47 @@ class ArchitectureLayerTest {
                 repository.doesNotDependOn(service)
             }
         }
+    }
+
+    @Test
+    fun `컨트롤러 구현체는 domain과 repository를 직접 참조하지 않는다`() {
+        val controllerFiles = controllerImplementationFiles()
+
+        assertNoImportsFrom(controllerFiles, "com.sight.domain")
+        assertNoImportsFrom(controllerFiles, "com.sight.repository")
+    }
+
+    @Test
+    fun `서비스는 Spring MVC와 Servlet 타입을 참조하지 않는다`() {
+        val serviceFiles =
+            Konsist.scopeFromDirectory("src/main/kotlin")
+                .files
+                .filter { it.packagee?.name?.startsWith("com.sight.service") == true }
+
+        assertNoImportsFrom(serviceFiles, "org.springframework.web.servlet")
+        assertNoImportsFrom(serviceFiles, "jakarta.servlet")
+    }
+
+    private fun controllerImplementationFiles() =
+        Konsist.scopeFromDirectory("src/main/kotlin")
+            .files
+            .filter {
+                it.packagee?.name == "com.sight.controllers.http" ||
+                    it.packagee?.name == "com.sight.controllers.discord"
+            }
+
+    private fun assertNoImportsFrom(
+        files: List<com.lemonappdev.konsist.api.declaration.KoFileDeclaration>,
+        prohibitedPackage: String,
+    ) {
+        val violations =
+            files.filter { file ->
+                file.imports.any { it.name.startsWith(prohibitedPackage) }
+            }
+
+        assertTrue(
+            violations.isEmpty(),
+            "${prohibitedPackage}를 직접 참조하는 파일: ${violations.joinToString { it.name }}",
+        )
     }
 }


### PR DESCRIPTION
## 변경 사항

- 컨트롤러 구현체의 `domain`·`repository` 직접 참조를 금지합니다.
- 서비스의 Spring MVC·Servlet 참조를 금지합니다.
- 도메인 enum query 해석을 서비스 경계로 이동합니다.

## 검증

- `./gradlew check --no-daemon`