### PR TITLE
feat: 가입신청서 문항 생성 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationQuestionController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationQuestionController.kt
@@ -1,0 +1,43 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.CreateApplicationQuestionRequest
+import com.sight.controllers.http.dto.CreateApplicationQuestionResponse
+import com.sight.core.auth.Auth
+import com.sight.core.auth.UserRole
+import com.sight.service.ApplicationQuestionService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ApplicationQuestionController(
+    private val applicationQuestionService: ApplicationQuestionService,
+) {
+    @Auth([UserRole.MANAGER])
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/manager/application-questions")
+    fun createQuestion(
+        @Valid @RequestBody request: CreateApplicationQuestionRequest,
+    ): CreateApplicationQuestionResponse {
+        val question =
+            applicationQuestionService.createQuestion(
+                title = request.title,
+                description = request.description,
+                minLength = request.minLength,
+            )
+
+        return CreateApplicationQuestionResponse(
+            id = question.id,
+            title = question.title,
+            description = question.description,
+            minLength = question.minLength,
+            order = question.order,
+            isExposed = question.isExposed,
+            createdAt = question.createdAt,
+            updatedAt = question.updatedAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationQuestionRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationQuestionRequest.kt
@@ -1,0 +1,15 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.PositiveOrZero
+
+data class CreateApplicationQuestionRequest(
+    @field:NotBlank
+    val title: String,
+
+    @field:NotBlank
+    val description: String,
+
+    @field:PositiveOrZero
+    val minLength: Int,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationQuestionResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/CreateApplicationQuestionResponse.kt
@@ -1,0 +1,14 @@
+package com.sight.controllers.http.dto
+
+import java.time.LocalDateTime
+
+data class CreateApplicationQuestionResponse(
+    val id: String,
+    val title: String,
+    val description: String,
+    val minLength: Int,
+    val order: Int?,
+    val isExposed: Boolean,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/sight/service/ApplicationQuestionService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationQuestionService.kt
@@ -1,0 +1,31 @@
+package com.sight.service
+
+import com.github.f4b6a3.ulid.UlidCreator
+import com.sight.domain.application.ApplicationQuestion
+import com.sight.repository.ApplicationQuestionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ApplicationQuestionService(
+    private val applicationQuestionRepository: ApplicationQuestionRepository,
+) {
+    @Transactional
+    fun createQuestion(
+        title: String,
+        description: String,
+        minLength: Int,
+    ): ApplicationQuestion {
+        val question =
+            ApplicationQuestion(
+                id = UlidCreator.getUlid().toString(),
+                title = title,
+                description = description,
+                minLength = minLength,
+                order = null,
+                isExposed = false,
+            )
+
+        return applicationQuestionRepository.save(question)
+    }
+}

--- a/src/test/kotlin/com/sight/controllers/http/ApplicationQuestionControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/ApplicationQuestionControllerTest.kt
@@ -1,0 +1,110 @@
+package com.sight.controllers.http
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sight.controllers.http.dto.CreateApplicationQuestionRequest
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
+import com.sight.domain.application.ApplicationQuestion
+import com.sight.service.ApplicationQuestionService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+@WebMvcTest(
+    ApplicationQuestionController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class],
+)
+class ApplicationQuestionControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    private lateinit var applicationQuestionService: ApplicationQuestionService
+
+    @BeforeEach
+    fun setUp() {
+        val requester = Requester(userId = 1L, role = UserRole.MANAGER)
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(
+                requester,
+                null,
+                listOf(SimpleGrantedAuthority("ROLE_MANAGER")),
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `가입 신청서 문항 생성 API는 201 Created와 생성된 문항을 반환한다`() {
+        val request =
+            CreateApplicationQuestionRequest(
+                title = "자기소개",
+                description = "자기소개를 작성해주세요.",
+                minLength = 100,
+            )
+        val now = LocalDateTime.now()
+        given(applicationQuestionService.createQuestion(request.title, request.description, request.minLength))
+            .willReturn(
+                ApplicationQuestion(
+                    id = "question-ulid",
+                    title = request.title,
+                    description = request.description,
+                    minLength = request.minLength,
+                    order = null,
+                    isExposed = false,
+                    createdAt = now,
+                    updatedAt = now,
+                ),
+            )
+
+        mockMvc.perform(
+            post("/manager/application-questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value("question-ulid"))
+            .andExpect(jsonPath("$.order").isEmpty)
+            .andExpect(jsonPath("$.isExposed").value(false))
+
+        verify(applicationQuestionService).createQuestion(request.title, request.description, request.minLength)
+    }
+
+    @Test
+    fun `가입 신청서 문항 생성 API는 빈 제목을 받으면 400 Bad Request를 반환한다`() {
+        val request =
+            CreateApplicationQuestionRequest(
+                title = " ",
+                description = "자기소개를 작성해주세요.",
+                minLength = 100,
+            )
+
+        mockMvc.perform(
+            post("/manager/application-questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+    }
+}

--- a/src/test/kotlin/com/sight/service/ApplicationQuestionServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationQuestionServiceTest.kt
@@ -1,0 +1,38 @@
+package com.sight.service
+
+import com.sight.domain.application.ApplicationQuestion
+import com.sight.repository.ApplicationQuestionRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class ApplicationQuestionServiceTest {
+    private val applicationQuestionRepository = mock<ApplicationQuestionRepository>()
+    private val service = ApplicationQuestionService(applicationQuestionRepository)
+
+    @Test
+    fun `createQuestion은 비노출 상태와 순서 없음으로 문항을 생성한다`() {
+        val captor = argumentCaptor<ApplicationQuestion>()
+        given(applicationQuestionRepository.save(any<ApplicationQuestion>())).willAnswer { it.arguments[0] }
+
+        val result =
+            service.createQuestion(
+                title = "자기소개",
+                description = "자기소개를 작성해주세요.",
+                minLength = 100,
+            )
+
+        verify(applicationQuestionRepository).save(captor.capture())
+        assertEquals(result, captor.firstValue)
+        assertEquals("자기소개", result.title)
+        assertEquals("자기소개를 작성해주세요.", result.description)
+        assertEquals(100, result.minLength)
+        assertEquals(null, result.order)
+        assertFalse(result.isExposed)
+    }
+}


### PR DESCRIPTION
1. Request Body에 주어진 값으로 `ApplicationQuestion` 객체를 생성합니다. 이때 id = ulid, order = null, isExposed = false로 지정합니다.
2. 저장합니다.
3. Response body 형태에 맞게 반환합니다.

### Query Parameters
- *(없음)*

### Request Body
- title: string, required
- description: string, required
- minLength: int, required

### Status Code
- 201

### Response Body
- id: string
- title: string
- description: string
- minLength: number
- order: number (null)
- isExposed: boolean (false)
- createdAt: string (ISO8601)
- updatedAt: string (ISO8601)
