### PR TITLE
feat: 가입신청서 문항 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationQuestionController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationQuestionController.kt
@@ -2,20 +2,48 @@ package com.sight.controllers.http
 
 import com.sight.controllers.http.dto.CreateApplicationQuestionRequest
 import com.sight.controllers.http.dto.CreateApplicationQuestionResponse
+import com.sight.controllers.http.dto.ListApplicationQuestionsResponse
 import com.sight.core.auth.Auth
 import com.sight.core.auth.UserRole
 import com.sight.service.ApplicationQuestionService
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
 import org.springframework.http.HttpStatus
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
+@Validated
 class ApplicationQuestionController(
     private val applicationQuestionService: ApplicationQuestionService,
 ) {
+    @GetMapping("/application-questions")
+    fun listQuestions(
+        @RequestParam
+        @Size(min = 1, max = 100)
+        applicationQuestionIds: List<String>,
+    ): ListApplicationQuestionsResponse {
+        val questions = applicationQuestionService.listQuestionsByIds(applicationQuestionIds)
+
+        return ListApplicationQuestionsResponse(
+            questions =
+                questions.map { question ->
+                    ListApplicationQuestionsResponse.QuestionResponse(
+                        id = question.id,
+                        title = question.title,
+                        description = question.description,
+                        minLength = question.minLength,
+                        order = question.order,
+                    )
+                },
+        )
+    }
+
     @Auth([UserRole.MANAGER])
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/manager/application-questions")

--- a/src/main/kotlin/com/sight/controllers/http/dto/ListApplicationQuestionsResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/ListApplicationQuestionsResponse.kt
@@ -1,0 +1,13 @@
+package com.sight.controllers.http.dto
+
+data class ListApplicationQuestionsResponse(
+    val questions: List<QuestionResponse>,
+) {
+    data class QuestionResponse(
+        val id: String,
+        val title: String,
+        val description: String,
+        val minLength: Int,
+        val order: Int?,
+    )
+}

--- a/src/main/kotlin/com/sight/service/ApplicationQuestionService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationQuestionService.kt
@@ -1,6 +1,7 @@
 package com.sight.service
 
 import com.github.f4b6a3.ulid.UlidCreator
+import com.sight.core.exception.NotFoundException
 import com.sight.domain.application.ApplicationQuestion
 import com.sight.repository.ApplicationQuestionRepository
 import org.springframework.stereotype.Service
@@ -27,5 +28,16 @@ class ApplicationQuestionService(
             )
 
         return applicationQuestionRepository.save(question)
+    }
+
+    @Transactional(readOnly = true)
+    fun listQuestionsByIds(applicationQuestionIds: List<String>): List<ApplicationQuestion> {
+        val distinctIds = applicationQuestionIds.distinct()
+        val questionsById = applicationQuestionRepository.findAllById(distinctIds).associateBy { it.id }
+        if (questionsById.size != distinctIds.size) {
+            throw NotFoundException("존재하지 않는 가입신청서 문항이 포함되어 있습니다")
+        }
+
+        return distinctIds.map { questionId -> questionsById.getValue(questionId) }
     }
 }

--- a/src/test/kotlin/com/sight/controllers/http/ApplicationQuestionControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/ApplicationQuestionControllerTest.kt
@@ -20,6 +20,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -106,5 +107,40 @@ class ApplicationQuestionControllerTest {
                 .content(objectMapper.writeValueAsString(request)),
         )
             .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `가입 신청서 문항 목록 조회 API는 요청한 문항을 반환한다`() {
+        given(applicationQuestionService.listQuestionsByIds(listOf("question-2", "question-1")))
+            .willReturn(
+                listOf(
+                    ApplicationQuestion(
+                        id = "question-2",
+                        title = "둘째 문항",
+                        description = "둘째 설명",
+                        minLength = 20,
+                        order = 2,
+                        isExposed = true,
+                    ),
+                    ApplicationQuestion(
+                        id = "question-1",
+                        title = "첫 문항",
+                        description = "첫 설명",
+                        minLength = 10,
+                        order = 1,
+                        isExposed = true,
+                    ),
+                ),
+            )
+
+        mockMvc.perform(
+            get("/application-questions")
+                .queryParam("applicationQuestionIds", "question-2", "question-1"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.questions[0].id").value("question-2"))
+            .andExpect(jsonPath("$.questions[1].id").value("question-1"))
+
+        verify(applicationQuestionService).listQuestionsByIds(listOf("question-2", "question-1"))
     }
 }

--- a/src/test/kotlin/com/sight/service/ApplicationQuestionServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationQuestionServiceTest.kt
@@ -1,10 +1,12 @@
 package com.sight.service
 
+import com.sight.core.exception.NotFoundException
 import com.sight.domain.application.ApplicationQuestion
 import com.sight.repository.ApplicationQuestionRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.given
@@ -34,5 +36,41 @@ class ApplicationQuestionServiceTest {
         assertEquals(100, result.minLength)
         assertEquals(null, result.order)
         assertFalse(result.isExposed)
+    }
+
+    @Test
+    fun `listQuestionsByIds는 요청한 문항 순서대로 반환한다`() {
+        val firstQuestion = question(id = "question-1", title = "첫 문항")
+        val secondQuestion = question(id = "question-2", title = "둘째 문항")
+        given(applicationQuestionRepository.findAllById(listOf("question-2", "question-1")))
+            .willReturn(listOf(firstQuestion, secondQuestion))
+
+        val result = service.listQuestionsByIds(listOf("question-2", "question-1"))
+
+        assertEquals(listOf("question-2", "question-1"), result.map { it.id })
+    }
+
+    @Test
+    fun `listQuestionsByIds는 존재하지 않는 문항이 있으면 NotFoundException을 던진다`() {
+        given(applicationQuestionRepository.findAllById(listOf("question-1", "missing-question")))
+            .willReturn(listOf(question(id = "question-1", title = "첫 문항")))
+
+        assertThrows<NotFoundException> {
+            service.listQuestionsByIds(listOf("question-1", "missing-question"))
+        }
+    }
+
+    private fun question(
+        id: String,
+        title: String,
+    ): ApplicationQuestion {
+        return ApplicationQuestion(
+            id = id,
+            title = title,
+            description = "설명",
+            minLength = 0,
+            order = null,
+            isExposed = false,
+        )
     }
 }


### PR DESCRIPTION
> 가입신청서가 생성된 후 가입신청서 항목이 수정되는 경우 회원이 단순히 `isExposed`인 항목 목록만 받으면 기존에 작성한 항목이 보여지지 않거나, 새로운 항목을 작성해야 하는 문제가 발생할 수 있습니다. 따라서 ID 목록을 기반으로 항목 목록을 조회하는 API가 필요합니다.

> 개인정보는 없으므로 별도 인증 처리는 하지 않습니다.

> 관련 가입신청서 항목의 노출 여부가 변경됨에 따라 `order`가 `null`로 내려올 가능성이 있습니다. 이 경우 프론트엔드에서는 `order`가 `null`인 항목을 `null`이 아닌 항목 뒤에 위치하게 구현하며, `order`가 `null`인 항목들끼리는 `id`를 기준으로 정렬합니다.

1. 주어진 `applicationQuestionIds`로 `ApplicationQuestion` 목록을 조회합니다.
2. 중복을 제거한 `applicationQuestionIds`의 개수와 조회된 `ApplicationQuestion`의 개수가 다르면 404.
3. 조회한 `ApplicationQuestion`를 Response body에 맞춰 반환합니다.

### Query Parameters
- `applicationQuestionIds: string[], required`

### Request Body
- *(없음)*

### Status Code
- 200

### Response Body
- questions: object\[\]
	- id: string
	- title: string
	- description: string
	- minLength: number
	- order: number, nullable
