### PR TITLE
feat: 가입신청서 문항 수정 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationQuestionController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationQuestionController.kt
@@ -3,15 +3,18 @@ package com.sight.controllers.http
 import com.sight.controllers.http.dto.CreateApplicationQuestionRequest
 import com.sight.controllers.http.dto.CreateApplicationQuestionResponse
 import com.sight.controllers.http.dto.ListApplicationQuestionsResponse
+import com.sight.controllers.http.dto.UpdateApplicationQuestionsRequest
 import com.sight.core.auth.Auth
 import com.sight.core.auth.UserRole
 import com.sight.service.ApplicationQuestionService
+import com.sight.service.UpdateApplicationQuestionCommand
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -66,6 +69,26 @@ class ApplicationQuestionController(
             isExposed = question.isExposed,
             createdAt = question.createdAt,
             updatedAt = question.updatedAt,
+        )
+    }
+
+    @Auth([UserRole.MANAGER])
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/manager/application-questions")
+    fun updateQuestions(
+        @Valid @RequestBody request: UpdateApplicationQuestionsRequest,
+    ) {
+        applicationQuestionService.updateQuestions(
+            request.questions.map { question ->
+                UpdateApplicationQuestionCommand(
+                    id = question.id,
+                    title = question.title,
+                    description = question.description,
+                    minLength = question.minLength,
+                    order = question.order,
+                    isExposed = question.isExposed,
+                )
+            },
         )
     }
 }

--- a/src/main/kotlin/com/sight/controllers/http/dto/UpdateApplicationQuestionsRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/UpdateApplicationQuestionsRequest.kt
@@ -1,0 +1,32 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
+
+data class UpdateApplicationQuestionsRequest(
+    @field:NotEmpty
+    @field:Valid
+    val questions: List<QuestionRequest>,
+) {
+    data class QuestionRequest(
+        @field:NotBlank
+        val id: String,
+
+        @field:NotBlank
+        val title: String,
+
+        @field:NotBlank
+        val description: String,
+
+        @field:PositiveOrZero
+        val minLength: Int,
+
+        @field:Positive
+        val order: Int?,
+
+        val isExposed: Boolean,
+    )
+}

--- a/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
@@ -11,28 +11,19 @@ import java.time.LocalDateTime
 @Entity
 @Table(name = "application_question")
 class ApplicationQuestion(
+    id: String,
+    title: String,
+    description: String,
+    minLength: Int,
+    order: Int? = null,
+    isExposed: Boolean,
+    createdAt: LocalDateTime = LocalDateTime.now(),
+    updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
     @Id
     @Column(name = "id", nullable = false, length = 100)
-    val id: String,
+    val id: String = id
 
-    title: String,
-
-    description: String,
-
-    minLength: Int,
-
-    order: Int? = null,
-
-    isExposed: Boolean,
-
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now(),
-
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    val updatedAt: LocalDateTime = LocalDateTime.now(),
-) {
     @Column(name = "title", nullable = false, length = 255)
     var title: String = title
         private set
@@ -53,8 +44,16 @@ class ApplicationQuestion(
     var isExposed: Boolean = isExposed
         private set
 
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = createdAt
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = updatedAt
+
     init {
-        requireValidState(minLength, order, isExposed)
+        requireValidState(minLength, order)
     }
 
     fun update(
@@ -64,7 +63,7 @@ class ApplicationQuestion(
         order: Int?,
         isExposed: Boolean,
     ) {
-        requireValidState(minLength, order, isExposed)
+        requireValidState(minLength, order)
 
         this.title = title
         this.description = description
@@ -76,10 +75,8 @@ class ApplicationQuestion(
     private fun requireValidState(
         minLength: Int,
         order: Int?,
-        isExposed: Boolean,
     ) {
         require(minLength >= 0) { "최소 글자 수는 0 이상이어야 합니다" }
         require(order == null || order > 0) { "문항 순서는 1 이상이어야 합니다" }
-        require(isExposed == (order != null)) { "노출 여부와 문항 순서는 함께 설정되어야 합니다" }
     }
 }

--- a/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
@@ -10,25 +10,20 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "application_question")
-data class ApplicationQuestion(
+class ApplicationQuestion(
     @Id
     @Column(name = "id", nullable = false, length = 100)
     val id: String,
 
-    @Column(name = "title", nullable = false, length = 255)
-    val title: String,
+    title: String,
 
-    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
-    val description: String,
+    description: String,
 
-    @Column(name = "min_length", nullable = false)
-    val minLength: Int,
+    minLength: Int,
 
-    @Column(name = "`order`", nullable = true)
-    val order: Int? = null,
+    order: Int? = null,
 
-    @Column(name = "is_exposed", nullable = false, columnDefinition = "TINYINT")
-    val isExposed: Boolean,
+    isExposed: Boolean,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
@@ -37,4 +32,54 @@ data class ApplicationQuestion(
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime = LocalDateTime.now(),
-)
+) {
+    @Column(name = "title", nullable = false, length = 255)
+    var title: String = title
+        private set
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    var description: String = description
+        private set
+
+    @Column(name = "min_length", nullable = false)
+    var minLength: Int = minLength
+        private set
+
+    @Column(name = "`order`", nullable = true)
+    var order: Int? = order
+        private set
+
+    @Column(name = "is_exposed", nullable = false, columnDefinition = "TINYINT")
+    var isExposed: Boolean = isExposed
+        private set
+
+    init {
+        requireValidState(minLength, order, isExposed)
+    }
+
+    fun update(
+        title: String,
+        description: String,
+        minLength: Int,
+        order: Int?,
+        isExposed: Boolean,
+    ) {
+        requireValidState(minLength, order, isExposed)
+
+        this.title = title
+        this.description = description
+        this.minLength = minLength
+        this.order = order
+        this.isExposed = isExposed
+    }
+
+    private fun requireValidState(
+        minLength: Int,
+        order: Int?,
+        isExposed: Boolean,
+    ) {
+        require(minLength >= 0) { "최소 글자 수는 0 이상이어야 합니다" }
+        require(order == null || order > 0) { "문항 순서는 1 이상이어야 합니다" }
+        require(isExposed == (order != null)) { "노출 여부와 문항 순서는 함께 설정되어야 합니다" }
+    }
+}

--- a/src/main/kotlin/com/sight/service/ApplicationQuestionService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationQuestionService.kt
@@ -1,6 +1,7 @@
 package com.sight.service
 
 import com.github.f4b6a3.ulid.UlidCreator
+import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.NotFoundException
 import com.sight.domain.application.ApplicationQuestion
 import com.sight.repository.ApplicationQuestionRepository
@@ -39,5 +40,42 @@ class ApplicationQuestionService(
         }
 
         return distinctIds.map { questionId -> questionsById.getValue(questionId) }
+    }
+
+    @Transactional
+    fun updateQuestions(commands: List<UpdateApplicationQuestionCommand>) {
+        validateQuestionOrders(commands)
+
+        val commandsById = commands.associateBy { it.id }
+        if (commandsById.size != commands.size) {
+            throw BadRequestException("중복된 가입신청서 문항 ID가 포함되어 있습니다")
+        }
+
+        val questions = applicationQuestionRepository.findAllById(commandsById.keys)
+        if (questions.size != commands.size) {
+            throw NotFoundException("존재하지 않는 가입신청서 문항이 포함되어 있습니다")
+        }
+
+        questions.forEach { question ->
+            val command = commandsById.getValue(question.id)
+            question.update(
+                title = command.title,
+                description = command.description,
+                minLength = command.minLength,
+                order = command.order,
+                isExposed = command.isExposed,
+            )
+        }
+        applicationQuestionRepository.saveAll(questions)
+    }
+
+    private fun validateQuestionOrders(commands: List<UpdateApplicationQuestionCommand>) {
+        val orders = commands.mapNotNull { it.order }.sorted()
+        if (orders != (1..orders.size).toList()) {
+            throw BadRequestException("노출된 가입신청서 문항의 순서는 1부터 연속되어야 합니다")
+        }
+        if (commands.any { it.isExposed != (it.order != null) }) {
+            throw BadRequestException("노출 여부와 문항 순서는 함께 설정되어야 합니다")
+        }
     }
 }

--- a/src/main/kotlin/com/sight/service/UpdateApplicationQuestionCommand.kt
+++ b/src/main/kotlin/com/sight/service/UpdateApplicationQuestionCommand.kt
@@ -1,0 +1,10 @@
+package com.sight.service
+
+data class UpdateApplicationQuestionCommand(
+    val id: String,
+    val title: String,
+    val description: String,
+    val minLength: Int,
+    val order: Int?,
+    val isExposed: Boolean,
+)

--- a/src/test/kotlin/com/sight/service/ApplicationQuestionServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationQuestionServiceTest.kt
@@ -1,10 +1,12 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.NotFoundException
 import com.sight.domain.application.ApplicationQuestion
 import com.sight.repository.ApplicationQuestionRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -57,6 +59,50 @@ class ApplicationQuestionServiceTest {
 
         assertThrows<NotFoundException> {
             service.listQuestionsByIds(listOf("question-1", "missing-question"))
+        }
+    }
+
+    @Test
+    fun `updateQuestions는 노출 여부와 순서가 유효하면 문항을 수정한다`() {
+        val question = question(id = "question-1", title = "기존 문항")
+        given(applicationQuestionRepository.findAllById(setOf("question-1"))).willReturn(listOf(question))
+
+        service.updateQuestions(
+            listOf(
+                UpdateApplicationQuestionCommand(
+                    id = "question-1",
+                    title = "수정 문항",
+                    description = "수정 설명",
+                    minLength = 10,
+                    order = 1,
+                    isExposed = true,
+                ),
+            ),
+        )
+
+        assertEquals("수정 문항", question.title)
+        assertEquals("수정 설명", question.description)
+        assertEquals(10, question.minLength)
+        assertEquals(1, question.order)
+        assertTrue(question.isExposed)
+        verify(applicationQuestionRepository).saveAll(listOf(question))
+    }
+
+    @Test
+    fun `updateQuestions는 노출 문항 순서가 연속되지 않으면 BadRequestException을 던진다`() {
+        assertThrows<BadRequestException> {
+            service.updateQuestions(
+                listOf(
+                    UpdateApplicationQuestionCommand(
+                        id = "question-1",
+                        title = "문항",
+                        description = "설명",
+                        minLength = 0,
+                        order = 2,
+                        isExposed = true,
+                    ),
+                ),
+            )
         }
     }
 


### PR DESCRIPTION
1. `questions[].order` 중 `null`이 아닌 값들을 정렬했을 때, 1부터 시작해서 1씩 올라가는 숫자 배열인지 확인합니다. 아니라면 400.
2. `questions[].isExposed`가 `false`인데 `order`가 `null`이 아니거나, `true`인데 `order`가 `null`인 경우가 존재하면 400.
3. `questions[].id`로 `ApplicationQuestion` 목록을 조회합니다.
4. `questions[].id` 개수와 조회한 `ApplicationQuestion` 개수가 다르면 404.
5. `questions[].id` 기준으로 각각 해당하는 `ApplicationQuestion`에 변경 사항을 반영합니다.
6. 저장합니다.

### Query Parameters
- *(없음)*

### Request Body
- questions: object\[\], required
	- id: string, required
	- title: string, required
	- description: string, required
	- minLength: int, required
	- order: int, nullable
	- isExposed: boolean, required

### Status Code
- 200

### Response Body
- *(없음)*
