### PR TITLE
feat: 운영진 가입신청서 문항 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationQuestionController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationQuestionController.kt
@@ -3,6 +3,7 @@ package com.sight.controllers.http
 import com.sight.controllers.http.dto.CreateApplicationQuestionRequest
 import com.sight.controllers.http.dto.CreateApplicationQuestionResponse
 import com.sight.controllers.http.dto.ListApplicationQuestionsResponse
+import com.sight.controllers.http.dto.ListManagerApplicationQuestionsResponse
 import com.sight.controllers.http.dto.UpdateApplicationQuestionsRequest
 import com.sight.core.auth.Auth
 import com.sight.core.auth.UserRole
@@ -25,6 +26,26 @@ import org.springframework.web.bind.annotation.RestController
 class ApplicationQuestionController(
     private val applicationQuestionService: ApplicationQuestionService,
 ) {
+    @Auth([UserRole.MANAGER])
+    @GetMapping("/manager/application-questions")
+    fun listAllQuestions(): ListManagerApplicationQuestionsResponse {
+        val questions = applicationQuestionService.listAllQuestions()
+
+        return ListManagerApplicationQuestionsResponse(
+            questions =
+                questions.map { question ->
+                    ListManagerApplicationQuestionsResponse.QuestionResponse(
+                        id = question.id,
+                        title = question.title,
+                        description = question.description,
+                        minLength = question.minLength,
+                        order = question.order,
+                        isExposed = question.isExposed,
+                    )
+                },
+        )
+    }
+
     @GetMapping("/application-questions")
     fun listQuestions(
         @RequestParam

--- a/src/main/kotlin/com/sight/controllers/http/dto/ListManagerApplicationQuestionsResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/ListManagerApplicationQuestionsResponse.kt
@@ -1,0 +1,14 @@
+package com.sight.controllers.http.dto
+
+data class ListManagerApplicationQuestionsResponse(
+    val questions: List<QuestionResponse>,
+) {
+    data class QuestionResponse(
+        val id: String,
+        val title: String,
+        val description: String,
+        val minLength: Int,
+        val order: Int?,
+        val isExposed: Boolean,
+    )
+}

--- a/src/main/kotlin/com/sight/service/ApplicationQuestionService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationQuestionService.kt
@@ -42,6 +42,9 @@ class ApplicationQuestionService(
         return distinctIds.map { questionId -> questionsById.getValue(questionId) }
     }
 
+    @Transactional(readOnly = true)
+    fun listAllQuestions(): List<ApplicationQuestion> = applicationQuestionRepository.findAll()
+
     @Transactional
     fun updateQuestions(commands: List<UpdateApplicationQuestionCommand>) {
         validateQuestionOrders(commands)

--- a/src/test/kotlin/com/sight/service/ApplicationQuestionServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationQuestionServiceTest.kt
@@ -63,6 +63,16 @@ class ApplicationQuestionServiceTest {
     }
 
     @Test
+    fun `listAllQuestions는 저장된 모든 문항을 반환한다`() {
+        val questions = listOf(question(id = "question-1", title = "첫 문항"))
+        given(applicationQuestionRepository.findAll()).willReturn(questions)
+
+        val result = service.listAllQuestions()
+
+        assertEquals(questions, result)
+    }
+
+    @Test
     fun `updateQuestions는 노출 여부와 순서가 유효하면 문항을 수정한다`() {
         val question = question(id = "question-1", title = "기존 문항")
         given(applicationQuestionRepository.findAllById(setOf("question-1"))).willReturn(listOf(question))


### PR DESCRIPTION
> 편집하다 삭제됨

1. 모든 `applicationQuestions`를 조회한다

### Query Parameters
- (없음)

### Request Body
- *(없음)*

### Status Code
- 200

### Response Body
- questions: object\[\]
	- id: string
	- title: string
	- description: string
	- minLength: number
	- order: number, nullable
	- isExposed: boolean
