### PR TITLE
feat: 가입신청서 임시저장 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -5,6 +5,7 @@ import com.sight.controllers.http.dto.CreateApplicationCommentRequest
 import com.sight.controllers.http.dto.CreateApplicationCommentResponse
 import com.sight.controllers.http.dto.CreateApplicationFormDraftRequest
 import com.sight.controllers.http.dto.CreateApplicationFormDraftResponse
+import com.sight.controllers.http.dto.SaveApplicationFormDraftRequest
 import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
@@ -86,6 +87,22 @@ class ApplicationFormController(
                 },
             createdAt = draft.createdAt,
             updatedAt = draft.updatedAt,
+        )
+    }
+
+    @PutMapping("/application-forms/{applicationFormId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun saveDraft(
+        @PathVariable applicationFormId: String,
+        @Valid @RequestBody request: SaveApplicationFormDraftRequest,
+    ) {
+        applicationFormService.saveDraft(
+            applicationFormId,
+            request.token,
+            request.interviewAvailableTimes.map {
+                it.date to it.time
+            },
+            request.contents.associate { it.questionId to it.content },
         )
     }
 

--- a/src/main/kotlin/com/sight/controllers/http/dto/SaveApplicationFormDraftRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/SaveApplicationFormDraftRequest.kt
@@ -1,0 +1,21 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+
+data class SaveApplicationFormDraftRequest(
+    @field:NotBlank val token: String,
+    @field:NotEmpty @field:Valid val interviewAvailableTimes: List<InterviewAvailableTimeRequest>,
+    @field:NotEmpty @field:Valid val contents: List<ContentRequest>,
+) {
+    data class InterviewAvailableTimeRequest(
+        @field:NotBlank val date: String,
+        @field:NotBlank val time: String,
+    )
+
+    data class ContentRequest(
+        @field:NotBlank val questionId: String,
+        val content: String,
+    )
+}

--- a/src/main/kotlin/com/sight/domain/application/ApplicationContent.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationContent.kt
@@ -11,29 +11,34 @@ import java.time.LocalDateTime
 @Entity
 @Table(name = "application_content")
 class ApplicationContent(
+    id: String,
+    applicationFormId: String,
+    questionId: String,
+    content: String,
+    createdAt: LocalDateTime = LocalDateTime.now(),
+    updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
     @Id
     @Column(name = "id", nullable = false, length = 100)
-    val id: String,
+    val id: String = id
 
     @Column(name = "application_form_id", nullable = false, length = 100)
-    val applicationFormId: String,
+    val applicationFormId: String = applicationFormId
 
     @Column(name = "question_id", nullable = false, length = 100)
-    val questionId: String,
+    val questionId: String = questionId
 
-    content: String,
-
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now(),
-
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    val updatedAt: LocalDateTime = LocalDateTime.now(),
-) {
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     var content: String = content
         private set
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = createdAt
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = updatedAt
 
     fun updateContent(content: String) {
         this.content = content

--- a/src/main/kotlin/com/sight/domain/application/ApplicationContent.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationContent.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "application_content")
-data class ApplicationContent(
+class ApplicationContent(
     @Id
     @Column(name = "id", nullable = false, length = 100)
     val id: String,
@@ -21,8 +21,7 @@ data class ApplicationContent(
     @Column(name = "question_id", nullable = false, length = 100)
     val questionId: String,
 
-    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
-    val content: String,
+    content: String,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
@@ -31,4 +30,12 @@ data class ApplicationContent(
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime = LocalDateTime.now(),
-)
+) {
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    var content: String = content
+        private set
+
+    fun updateContent(content: String) {
+        this.content = content
+    }
+}

--- a/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
@@ -11,28 +11,19 @@ import java.time.LocalDateTime
 @Entity
 @Table(name = "application_question")
 class ApplicationQuestion(
+    id: String,
+    title: String,
+    description: String,
+    minLength: Int,
+    order: Int? = null,
+    isExposed: Boolean,
+    createdAt: LocalDateTime = LocalDateTime.now(),
+    updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
     @Id
     @Column(name = "id", nullable = false, length = 100)
-    val id: String,
+    val id: String = id
 
-    title: String,
-
-    description: String,
-
-    minLength: Int,
-
-    order: Int? = null,
-
-    isExposed: Boolean,
-
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now(),
-
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    val updatedAt: LocalDateTime = LocalDateTime.now(),
-) {
     @Column(name = "title", nullable = false, length = 255)
     var title: String = title
         private set
@@ -52,6 +43,14 @@ class ApplicationQuestion(
     @Column(name = "is_exposed", nullable = false, columnDefinition = "TINYINT")
     var isExposed: Boolean = isExposed
         private set
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = createdAt
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = updatedAt
 
     init {
         requireValidState(minLength, order)

--- a/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
@@ -54,7 +54,7 @@ class ApplicationQuestion(
         private set
 
     init {
-        requireValidState(minLength, order, isExposed)
+        requireValidState(minLength, order)
     }
 
     fun update(
@@ -64,7 +64,7 @@ class ApplicationQuestion(
         order: Int?,
         isExposed: Boolean,
     ) {
-        requireValidState(minLength, order, isExposed)
+        requireValidState(minLength, order)
 
         this.title = title
         this.description = description
@@ -76,10 +76,8 @@ class ApplicationQuestion(
     private fun requireValidState(
         minLength: Int,
         order: Int?,
-        isExposed: Boolean,
     ) {
         require(minLength >= 0) { "최소 글자 수는 0 이상이어야 합니다" }
         require(order == null || order > 0) { "문항 순서는 1 이상이어야 합니다" }
-        require(isExposed == (order != null)) { "노출 여부와 문항 순서는 함께 설정되어야 합니다" }
     }
 }

--- a/src/main/kotlin/com/sight/repository/ApplicationFormAuthTokenRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ApplicationFormAuthTokenRepository.kt
@@ -3,4 +3,6 @@ package com.sight.repository
 import com.sight.domain.application.ApplicationFormAuthToken
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ApplicationFormAuthTokenRepository : JpaRepository<ApplicationFormAuthToken, String>
+interface ApplicationFormAuthTokenRepository : JpaRepository<ApplicationFormAuthToken, String> {
+    fun findFirstByApplicationFormIdOrderByCreatedAtDesc(applicationFormId: String): ApplicationFormAuthToken?
+}

--- a/src/main/kotlin/com/sight/repository/InterviewAvailableTimeRepository.kt
+++ b/src/main/kotlin/com/sight/repository/InterviewAvailableTimeRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface InterviewAvailableTimeRepository : JpaRepository<InterviewAvailableTime, String> {
     fun findAllByApplicationFormId(applicationFormId: String): List<InterviewAvailableTime>
+
+    fun deleteAllByApplicationFormId(applicationFormId: String)
 }

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -145,25 +145,41 @@ class ApplicationFormService(
         times: List<Pair<String, String>>,
         contents: Map<String, String>,
     ) {
-        val authToken =
-            applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(applicationFormId)
-                ?: throw UnauthorizedException("가입신청서 인증 토큰이 없습니다")
-        if (authToken.token != token || !authToken.expiredAt.isAfter(LocalDateTime.now())) {
-            throw UnauthorizedException(
-                "가입신청서 인증 토큰이 유효하지 않습니다",
-            )
-        }
-        val form = applicationFormRepository.findById(applicationFormId).orElseThrow { NotFoundException("가입신청서를 찾을 수 없습니다") }
+        validateAuthToken(applicationFormId, token)
+
+        val form =
+            applicationFormRepository.findById(applicationFormId).orElseThrow {
+                NotFoundException("가입신청서를 찾을 수 없습니다")
+            }
+
         val storedContents = applicationContentRepository.findAllByApplicationFormId(form.id)
-        if (storedContents.map { it.questionId }.toSet() != contents.keys) throw BadRequestException("가입신청서 문항이 일치하지 않습니다")
+        if (storedContents.map { it.questionId }.toSet() != contents.keys) {
+            throw BadRequestException("가입신청서 문항이 일치하지 않습니다")
+        }
+
         storedContents.forEach { it.updateContent(contents.getValue(it.questionId)) }
         applicationContentRepository.saveAll(storedContents)
+
         interviewAvailableTimeRepository.deleteAllByApplicationFormId(applicationFormId)
+
         interviewAvailableTimeRepository.saveAll(
             times.map { (date, time) ->
                 InterviewAvailableTime(UlidCreator.getUlid().toString(), applicationFormId, "$date $time")
             },
         )
+    }
+
+    private fun validateAuthToken(
+        applicationFormId: String,
+        token: String,
+    ) {
+        val authToken =
+            applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(applicationFormId)
+                ?: throw UnauthorizedException("가입신청서 인증 토큰이 없습니다")
+
+        if (authToken.token != token || !authToken.expiredAt.isAfter(LocalDateTime.now())) {
+            throw UnauthorizedException("가입신청서 인증 토큰이 유효하지 않습니다")
+        }
     }
 
     private fun createApplicationForm(

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -1,6 +1,7 @@
 package com.sight.service
 
 import com.github.f4b6a3.ulid.UlidCreator
+import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.NotFoundException
 import com.sight.core.exception.UnauthorizedException
 import com.sight.core.exception.UnprocessableEntityException
@@ -12,6 +13,7 @@ import com.sight.domain.application.ApplicationForm
 import com.sight.domain.application.ApplicationFormAuthToken
 import com.sight.domain.application.ApplicationFormStatus
 import com.sight.domain.application.ApplicationQuestion
+import com.sight.domain.application.InterviewAvailableTime
 import com.sight.repository.ApplicationCommentRepository
 import com.sight.repository.ApplicationContentRepository
 import com.sight.repository.ApplicationFormAuthTokenRepository
@@ -134,6 +136,34 @@ class ApplicationFormService(
                 .orElseThrow { NotFoundException("가입신청서를 찾을 수 없습니다") }
 
         applicationFormRepository.save(applicationForm.copy(assignedUserId = managerUserId))
+    }
+
+    @Transactional
+    fun saveDraft(
+        applicationFormId: String,
+        token: String,
+        times: List<Pair<String, String>>,
+        contents: Map<String, String>,
+    ) {
+        val authToken =
+            applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(applicationFormId)
+                ?: throw UnauthorizedException("가입신청서 인증 토큰이 없습니다")
+        if (authToken.token != token || !authToken.expiredAt.isAfter(LocalDateTime.now())) {
+            throw UnauthorizedException(
+                "가입신청서 인증 토큰이 유효하지 않습니다",
+            )
+        }
+        val form = applicationFormRepository.findById(applicationFormId).orElseThrow { NotFoundException("가입신청서를 찾을 수 없습니다") }
+        val storedContents = applicationContentRepository.findAllByApplicationFormId(form.id)
+        if (storedContents.map { it.questionId }.toSet() != contents.keys) throw BadRequestException("가입신청서 문항이 일치하지 않습니다")
+        storedContents.forEach { it.updateContent(contents.getValue(it.questionId)) }
+        applicationContentRepository.saveAll(storedContents)
+        interviewAvailableTimeRepository.deleteAllByApplicationFormId(applicationFormId)
+        interviewAvailableTimeRepository.saveAll(
+            times.map { (date, time) ->
+                InterviewAvailableTime(UlidCreator.getUlid().toString(), applicationFormId, "$date $time")
+            },
+        )
     }
 
     private fun createApplicationForm(

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -1,5 +1,6 @@
 package com.sight.service
 
+import com.sight.core.exception.BadRequestException
 import com.sight.core.exception.NotFoundException
 import com.sight.core.exception.UnauthorizedException
 import com.sight.core.exception.UnprocessableEntityException
@@ -10,6 +11,7 @@ import com.sight.core.info21.StuauthResponse
 import com.sight.domain.application.ApplicationComment
 import com.sight.domain.application.ApplicationContent
 import com.sight.domain.application.ApplicationForm
+import com.sight.domain.application.ApplicationFormAuthToken
 import com.sight.domain.application.ApplicationFormStatus
 import com.sight.domain.application.ApplicationQuestion
 import com.sight.domain.application.InterviewAvailableTime
@@ -609,5 +611,45 @@ class ApplicationFormServiceTest {
         }
 
         verify(applicationFormRepository).findById(applicationFormId)
+    }
+
+    @Test
+    fun `saveDraft는 인증된 신청서의 답변과 면접 가능 시간을 저장한다`() {
+        val formId = "form-1"
+        val form = ApplicationForm(formId, "info21", "홍길동", ApplicationFormStatus.DRAFT)
+        val content = ApplicationContent("content-1", formId, "question-1", "기존 답변")
+        val token = ApplicationFormAuthToken("token-1", formId, "valid-token", LocalDateTime.now().plusHours(1))
+        given(applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(formId)).willReturn(token)
+        given(applicationFormRepository.findById(formId)).willReturn(Optional.of(form))
+        given(applicationContentRepository.findAllByApplicationFormId(formId)).willReturn(listOf(content))
+
+        service.saveDraft(formId, "valid-token", listOf("2026-06-01" to "10:00"), mapOf("question-1" to "수정 답변"))
+
+        assertEquals("수정 답변", content.content)
+        verify(applicationContentRepository).saveAll(listOf(content))
+        verify(interviewAvailableTimeRepository).deleteAllByApplicationFormId(formId)
+        verify(interviewAvailableTimeRepository).saveAll(any<List<InterviewAvailableTime>>())
+    }
+
+    @Test
+    fun `saveDraft는 유효하지 않은 토큰이면 UnauthorizedException을 던진다`() {
+        val formId = "form-1"
+        val expired = ApplicationFormAuthToken("token-1", formId, "token", LocalDateTime.now().minusSeconds(1))
+        given(applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(formId)).willReturn(expired)
+
+        assertThrows<UnauthorizedException> { service.saveDraft(formId, "token", emptyList(), emptyMap()) }
+        verify(applicationFormRepository, never()).findById(any())
+    }
+
+    @Test
+    fun `saveDraft는 문항 목록이 일치하지 않으면 BadRequestException을 던진다`() {
+        val formId = "form-1"
+        val form = ApplicationForm(formId, "info21", "홍길동", ApplicationFormStatus.DRAFT)
+        val token = ApplicationFormAuthToken("token-1", formId, "token", LocalDateTime.now().plusHours(1))
+        given(applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(formId)).willReturn(token)
+        given(applicationFormRepository.findById(formId)).willReturn(Optional.of(form))
+        given(applicationContentRepository.findAllByApplicationFormId(formId)).willReturn(emptyList())
+
+        assertThrows<BadRequestException> { service.saveDraft(formId, "token", emptyList(), mapOf("question-1" to "답변")) }
     }
 }


### PR DESCRIPTION
1. request body의 `interviewAvailableTimes`에서 동일한 `date` + `time` 조합이 있으면 400.
2. request body의 `contents`에서 중복된 `questionId`가 존재하면 400.
3. 주어진 `applicationFormId`로 `ApplicationFormAuthToken`을 조회합니다. 없으면 401.
4. 조회한 `ApplicationFormAuthToken`의 `expiredAt`이 현재거나 현재보다 과거면 401.
5. 조회한 `ApplicationFormAuthToken`의 `token`과 요청의 `token`이 동일한지 확인하고, 다르면 401.
6. 주어진 `applicationFormId`로 `ApplicationForm`을 조회합니다. 없으면 404.
7. 저장된 `ApplicationContent` 중 `applicationFormId`가 주어진 값과 동일한 엔티티를 모두 조회합니다.
8. request body 데이터의 `contents[].questionId` 목록이 조회한 `ApplicationContent.questionId` 목록과 동일한 값을 갖고 있는지 확인하여 다르면 400.
9. `contents[].questionId`와 `ApplicationContent.questionId`를 기준으로 `content`를 대응시켜 `ApplicationContent`에 대입합니다.
10. 저장된 `InterviewAvailableTime` 중 `applicationFormId`가 주어진 값과 동일한 엔티티들을 모두 제거합니다.
11. request body의 `interviewAvailableTimes`로 새로운 `InterviewAvailableTime` 객체들을 생성합니다.
12. 수정한 `ApplicationContent` 및 생성한 `InterviewAvailableTime`을 저장합니다.

### Query Parameters
- *(없음)*

### Request Body
- token: string
- interviewAvailableTimes: object\[\]
	- date: string
	- time: string
- contents: object\[\]
	- questionId: string
	- content: string

### Status Code
- 200

### Response Body
- *(없음)*
