### PR TITLE
feat: 가입신청서 제출 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -6,6 +6,7 @@ import com.sight.controllers.http.dto.CreateApplicationCommentResponse
 import com.sight.controllers.http.dto.CreateApplicationFormDraftRequest
 import com.sight.controllers.http.dto.CreateApplicationFormDraftResponse
 import com.sight.controllers.http.dto.SaveApplicationFormDraftRequest
+import com.sight.controllers.http.dto.SubmitApplicationFormRequest
 import com.sight.core.auth.Auth
 import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
@@ -104,6 +105,15 @@ class ApplicationFormController(
             },
             request.contents.associate { it.questionId to it.content },
         )
+    }
+
+    @PostMapping("/application-forms/{applicationFormId}/submit")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun submit(
+        @PathVariable applicationFormId: String,
+        @Valid @RequestBody request: SubmitApplicationFormRequest,
+    ) {
+        applicationFormService.submit(applicationFormId, request.token)
     }
 
     @Auth([UserRole.MANAGER])

--- a/src/main/kotlin/com/sight/controllers/http/dto/SubmitApplicationFormRequest.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/SubmitApplicationFormRequest.kt
@@ -1,0 +1,7 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class SubmitApplicationFormRequest(
+    @field:NotBlank val token: String,
+)

--- a/src/main/kotlin/com/sight/domain/application/ApplicationForm.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationForm.kt
@@ -12,29 +12,59 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "application_form")
-data class ApplicationForm(
+class ApplicationForm(
+    id: String,
+    info21Id: String,
+    submittee: String,
+    status: ApplicationFormStatus,
+    assignedUserId: Long? = null,
+    createdAt: LocalDateTime = LocalDateTime.now(),
+    updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
     @Id
     @Column(name = "id", nullable = false, length = 100)
-    val id: String,
+    val id: String = id
 
     @Column(name = "info21_id", nullable = false, length = 100)
-    val info21Id: String,
+    val info21Id: String = info21Id
 
     @Column(name = "submittee", nullable = false, length = 255)
-    val submittee: String,
+    val submittee: String = submittee
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 50)
-    val status: ApplicationFormStatus,
+    var status: ApplicationFormStatus = status
+        private set
 
     @Column(name = "assigned_user_id", nullable = true)
-    val assignedUserId: Long? = null,
+    var assignedUserId: Long? = assignedUserId
+        private set
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = createdAt
 
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
-    val updatedAt: LocalDateTime = LocalDateTime.now(),
-)
+    val updatedAt: LocalDateTime = updatedAt
+
+    fun assignManager(managerUserId: Long) {
+        assignedUserId = managerUserId
+    }
+
+    fun submit() {
+        require(status == ApplicationFormStatus.DRAFT) { "임시저장 상태의 가입신청서만 제출할 수 있습니다" }
+        status = ApplicationFormStatus.SUBMITTED
+    }
+
+    fun pass() = changeSubmittedStatus(ApplicationFormStatus.PASSED)
+
+    fun reject() = changeSubmittedStatus(ApplicationFormStatus.REJECTED)
+
+    fun suspend() = changeSubmittedStatus(ApplicationFormStatus.SUSPENDED)
+
+    private fun changeSubmittedStatus(targetStatus: ApplicationFormStatus) {
+        require(status == ApplicationFormStatus.SUBMITTED) { "제출된 상태의 가입신청서만 상태를 변경할 수 있습니다" }
+        status = targetStatus
+    }
+}

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -135,7 +135,8 @@ class ApplicationFormService(
             applicationFormRepository.findById(applicationFormId)
                 .orElseThrow { NotFoundException("가입신청서를 찾을 수 없습니다") }
 
-        applicationFormRepository.save(applicationForm.copy(assignedUserId = managerUserId))
+        applicationForm.assignManager(managerUserId)
+        applicationFormRepository.save(applicationForm)
     }
 
     @Transactional
@@ -180,10 +181,12 @@ class ApplicationFormService(
             applicationFormRepository.findById(applicationFormId).orElseThrow {
                 NotFoundException("가입신청서를 찾을 수 없습니다")
             }
-        if (form.status != ApplicationFormStatus.DRAFT) {
-            throw UnprocessableEntityException("임시저장 상태의 가입신청서만 제출할 수 있습니다")
+        try {
+            form.submit()
+        } catch (exception: IllegalArgumentException) {
+            throw UnprocessableEntityException(exception.message ?: "가입신청서를 제출할 수 없습니다")
         }
-        applicationFormRepository.save(form.copy(status = ApplicationFormStatus.SUBMITTED))
+        applicationFormRepository.save(form)
     }
 
     private fun validateAuthToken(
@@ -260,9 +263,7 @@ class ApplicationFormService(
             }
 
         // 2. 조회한 가입신청서의 status가 제출됨 상태인지 확인합니다. 이미 합격/불합격/중단 상태라면 422.
-        if (applicationForm.status != ApplicationFormStatus.SUBMITTED) {
-            throw UnprocessableEntityException("제출된 상태의 가입신청서만 합격 처리할 수 있습니다: ${applicationForm.status}")
-        }
+        changeApplicationFormStatus(applicationForm) { applicationForm.pass() }
 
         // 3. ApplicationComment 객체를 생성합니다.(id = ulid, applicationFormId = path parameter, authorUserId = 요청한 운영진 유저 ID, content = “가입신청서가 합격 처리되었습니다.”)
         val comment =
@@ -281,8 +282,7 @@ class ApplicationFormService(
         createKhlugMember(applicationForm)
 
         // 7. 저장합니다.
-        val updatedForm = applicationForm.copy(status = ApplicationFormStatus.PASSED)
-        return applicationFormRepository.save(updatedForm)
+        return applicationFormRepository.save(applicationForm)
     }
 
     private fun createKhlugMember(applicationForm: ApplicationForm) {
@@ -302,9 +302,7 @@ class ApplicationFormService(
             }
 
         // 2. 조회한 가입신청서의 status가 제출됨 상태인지 확인합니다. 이미 합격/불합격/중단 상태라면 422.
-        if (applicationForm.status != ApplicationFormStatus.SUBMITTED) {
-            throw UnprocessableEntityException("제출된 상태의 가입신청서만 불합격 처리할 수 있습니다: ${applicationForm.status}")
-        }
+        changeApplicationFormStatus(applicationForm) { applicationForm.reject() }
 
         // 3. ApplicationComment 객체를 생성합니다.(id = ulid, applicationFormId = path parameter, authorUserId = 요청한 운영진 유저 ID, content = “가입신청서가 불합격 처리되었습니다.”)
         val comment =
@@ -319,10 +317,8 @@ class ApplicationFormService(
         applicationCommentRepository.save(comment)
 
         // 5. 해당 가입신청서의 status를 불합격으로 변경합니다.
-        val updatedForm = applicationForm.copy(status = ApplicationFormStatus.REJECTED)
-
         // 6. 저장합니다.
-        return applicationFormRepository.save(updatedForm)
+        return applicationFormRepository.save(applicationForm)
     }
 
     @Transactional
@@ -337,9 +333,7 @@ class ApplicationFormService(
             }
 
         // 2. 조회한 가입신청서의 status가 제출됨 상태인지 확인합니다. 이미 합격/불합격/중단 상태라면 422.
-        if (applicationForm.status != ApplicationFormStatus.SUBMITTED) {
-            throw UnprocessableEntityException("제출된 상태의 가입신청서만 중단 처리할 수 있습니다: ${applicationForm.status}")
-        }
+        changeApplicationFormStatus(applicationForm) { applicationForm.suspend() }
 
         // 3. ApplicationComment 객체를 생성합니다.(id = ulid, applicationFormId = path parameter, authorUserId = 요청한 운영진 유저 ID, content = “가입신청서가 중단 처리되었습니다.”)
         val comment =
@@ -354,9 +348,18 @@ class ApplicationFormService(
         applicationCommentRepository.save(comment)
 
         // 5. 해당 가입신청서의 status를 중단으로 변경합니다.
-        val updatedForm = applicationForm.copy(status = ApplicationFormStatus.SUSPENDED)
-
         // 6. 저장합니다.
-        return applicationFormRepository.save(updatedForm)
+        return applicationFormRepository.save(applicationForm)
+    }
+
+    private fun changeApplicationFormStatus(
+        applicationForm: ApplicationForm,
+        changeStatus: () -> Unit,
+    ) {
+        try {
+            changeStatus()
+        } catch (exception: IllegalArgumentException) {
+            throw UnprocessableEntityException("제출된 상태의 가입신청서만 상태를 변경할 수 있습니다: ${applicationForm.status}")
+        }
     }
 }

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -166,6 +166,24 @@ class ApplicationFormService(
         )
     }
 
+    @Transactional
+    fun submit(
+        applicationFormId: String,
+        token: String,
+    ) {
+        val authToken =
+            applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(applicationFormId)
+                ?: throw UnauthorizedException("가입신청서 인증 토큰이 없습니다")
+        if (authToken.token != token || !authToken.expiredAt.isAfter(LocalDateTime.now())) {
+            throw UnauthorizedException(
+                "가입신청서 인증 토큰이 유효하지 않습니다",
+            )
+        }
+        val form = applicationFormRepository.findById(applicationFormId).orElseThrow { NotFoundException("가입신청서를 찾을 수 없습니다") }
+        if (form.status != ApplicationFormStatus.DRAFT) throw UnprocessableEntityException("임시저장 상태의 가입신청서만 제출할 수 있습니다")
+        applicationFormRepository.save(form.copy(status = ApplicationFormStatus.SUBMITTED))
+    }
+
     private fun createApplicationForm(
         info21Id: String,
         submittee: String,

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -361,7 +361,7 @@ class ApplicationFormServiceTest {
         given(applicationCommentRepository.save(any<ApplicationComment>()))
             .willReturn(savedComment)
         given(applicationFormRepository.save(any<ApplicationForm>()))
-            .willReturn(applicationForm.copy(status = ApplicationFormStatus.PASSED))
+            .willReturn(applicationForm)
 
         // when
         val result =
@@ -454,7 +454,7 @@ class ApplicationFormServiceTest {
         given(applicationCommentRepository.save(any<ApplicationComment>()))
             .willReturn(savedComment)
         given(applicationFormRepository.save(any<ApplicationForm>()))
-            .willReturn(applicationForm.copy(status = ApplicationFormStatus.REJECTED))
+            .willReturn(applicationForm)
 
         // when
         val result =
@@ -547,7 +547,7 @@ class ApplicationFormServiceTest {
         given(applicationCommentRepository.save(any<ApplicationComment>()))
             .willReturn(savedComment)
         given(applicationFormRepository.save(any<ApplicationForm>()))
-            .willReturn(applicationForm.copy(status = ApplicationFormStatus.SUSPENDED))
+            .willReturn(applicationForm)
 
         // when
         val result =

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -652,4 +652,41 @@ class ApplicationFormServiceTest {
 
         assertThrows<BadRequestException> { service.saveDraft(formId, "token", emptyList(), mapOf("question-1" to "답변")) }
     }
+
+    @Test
+    fun `submit은 인증된 임시저장 신청서를 제출 상태로 저장한다`() {
+        val formId = "form-1"
+        val form = ApplicationForm(formId, "info21", "홍길동", ApplicationFormStatus.DRAFT)
+        val token = ApplicationFormAuthToken("token-1", formId, "valid-token", LocalDateTime.now().plusHours(1))
+        val formCaptor = argumentCaptor<ApplicationForm>()
+        given(applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(formId)).willReturn(token)
+        given(applicationFormRepository.findById(formId)).willReturn(Optional.of(form))
+
+        service.submit(formId, "valid-token")
+
+        verify(applicationFormRepository).save(formCaptor.capture())
+        assertEquals(ApplicationFormStatus.SUBMITTED, formCaptor.firstValue.status)
+    }
+
+    @Test
+    fun `submit은 유효하지 않은 토큰이면 UnauthorizedException을 던진다`() {
+        val formId = "form-1"
+        val token = ApplicationFormAuthToken("token-1", formId, "valid-token", LocalDateTime.now().plusHours(1))
+        given(applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(formId)).willReturn(token)
+
+        assertThrows<UnauthorizedException> { service.submit(formId, "wrong-token") }
+        verify(applicationFormRepository, never()).findById(any())
+    }
+
+    @Test
+    fun `submit은 임시저장 상태가 아니면 UnprocessableEntityException을 던진다`() {
+        val formId = "form-1"
+        val form = ApplicationForm(formId, "info21", "홍길동", ApplicationFormStatus.SUBMITTED)
+        val token = ApplicationFormAuthToken("token-1", formId, "valid-token", LocalDateTime.now().plusHours(1))
+        given(applicationFormAuthTokenRepository.findFirstByApplicationFormIdOrderByCreatedAtDesc(formId)).willReturn(token)
+        given(applicationFormRepository.findById(formId)).willReturn(Optional.of(form))
+
+        assertThrows<UnprocessableEntityException> { service.submit(formId, "valid-token") }
+        verify(applicationFormRepository, never()).save(any())
+    }
 }


### PR DESCRIPTION
> 가입 신청 들어오면 운영진 디스코드로 웹훅 전송해야 함

1. 주어진 `applicationFormId`로 `ApplicationFormAuthToken`을 조회합니다. 없으면 401.
2. 조회한 `ApplicationFormAuthToken`의 `expiredAt`이 현재거나 현재보다 과거면 401.
3. 조회한 `ApplicationFormAuthToken`의 `token`과 요청의 `token`이 동일한지 확인하고, 다르면 401.
4. 주어진 `applicationFormId`로 `ApplicationForm`을 조회합니다. 없으면 404.
5. 주어진 `applicationFormId`로 모든 `ApplicationContent`들을 조회합니다.
6. 조회한 `ApplicationContent`들의 `questionId`들로 `ApplicationQuestion` 목록을 조회합니다.
7. 조회한 `ApplicationContent`들을 하나씩 순회하면서 해당하는 `ApplicationQuestion`에 지정된 `minLength`보다 `content`의 길이가 길거나 같은지 확인합니다.
	1. 이때, 해당하는 `ApplicationQuestion`이 존재하지 않는 경우 404 에러를 발생시키는데 메시지는 “잘못된 가입신청서 내용입니다. 운영진에게 문의해주세요.”로 반환합니다.
	2. 만약 `content`의 길이가 `minLength`보다 짧은 경우 422.
8. `ApplicationForm`의 `status`를 제출됨으로 변경합니다.
9. 저장합니다.
10. 관련 프론트엔드 링크, 제출자 학과 및 이름(`submittee`)을 운영진 디스코드 웹훅으로 전송합니다.

### Query Parameters
- *(없음)*

### Request Body
- token: string

### Status Code
- 200

### Response Body
- *(없음)*
