### PR TITLE
feat: 운영진 가입신청서 상세 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -5,6 +5,7 @@ import com.sight.controllers.http.dto.CreateApplicationCommentRequest
 import com.sight.controllers.http.dto.CreateApplicationCommentResponse
 import com.sight.controllers.http.dto.CreateApplicationFormDraftRequest
 import com.sight.controllers.http.dto.CreateApplicationFormDraftResponse
+import com.sight.controllers.http.dto.GetApplicationFormDetailResponse
 import com.sight.controllers.http.dto.SaveApplicationFormDraftRequest
 import com.sight.controllers.http.dto.SubmitApplicationFormRequest
 import com.sight.core.auth.Auth
@@ -14,6 +15,7 @@ import com.sight.service.ApplicationFormService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -26,6 +28,34 @@ import org.springframework.web.bind.annotation.RestController
 class ApplicationFormController(
     private val applicationFormService: ApplicationFormService,
 ) {
+    @Auth([UserRole.MANAGER])
+    @GetMapping("/manager/application-forms/{applicationFormId}")
+    fun getDetail(
+        @PathVariable applicationFormId: String,
+    ): GetApplicationFormDetailResponse {
+        val detail = applicationFormService.getDetail(applicationFormId)
+        return GetApplicationFormDetailResponse(
+            detail.form.id,
+            detail.form.submittee,
+            detail.form.status,
+            detail.form.assignedUserId,
+            detail.contents.map {
+                GetApplicationFormDetailResponse.Content(it.questionId, it.content)
+            },
+            detail.times.map {
+                GetApplicationFormDetailResponse.Time(it.availableAt)
+            },
+            detail.comments.map {
+                GetApplicationFormDetailResponse.Comment(
+                    it.id,
+                    it.authorUserId,
+                    it.content,
+                    it.createdAt,
+                )
+            },
+        )
+    }
+
     @Auth([UserRole.USER, UserRole.MANAGER])
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/application-forms/{applicationFormId}/comments")

--- a/src/main/kotlin/com/sight/controllers/http/dto/GetApplicationFormDetailResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/GetApplicationFormDetailResponse.kt
@@ -1,0 +1,20 @@
+package com.sight.controllers.http.dto
+
+import com.sight.domain.application.ApplicationFormStatus
+import java.time.LocalDateTime
+
+data class GetApplicationFormDetailResponse(
+    val id: String,
+    val submittee: String,
+    val status: ApplicationFormStatus,
+    val assignedUserId: Long?,
+    val contents: List<Content>,
+    val interviewAvailableTimes: List<Time>,
+    val comments: List<Comment>,
+) {
+    data class Content(val questionId: String, val content: String)
+
+    data class Time(val availableAt: String)
+
+    data class Comment(val id: String, val authorUserId: Long, val content: String, val createdAt: LocalDateTime)
+}

--- a/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
+++ b/src/main/kotlin/com/sight/domain/application/ApplicationQuestion.kt
@@ -54,7 +54,7 @@ class ApplicationQuestion(
         private set
 
     init {
-        requireValidState(minLength, order, isExposed)
+        requireValidState(minLength, order)
     }
 
     fun update(
@@ -64,7 +64,7 @@ class ApplicationQuestion(
         order: Int?,
         isExposed: Boolean,
     ) {
-        requireValidState(minLength, order, isExposed)
+        requireValidState(minLength, order)
 
         this.title = title
         this.description = description
@@ -76,10 +76,8 @@ class ApplicationQuestion(
     private fun requireValidState(
         minLength: Int,
         order: Int?,
-        isExposed: Boolean,
     ) {
         require(minLength >= 0) { "최소 글자 수는 0 이상이어야 합니다" }
         require(order == null || order > 0) { "문항 순서는 1 이상이어야 합니다" }
-        require(isExposed == (order != null)) { "노출 여부와 문항 순서는 함께 설정되어야 합니다" }
     }
 }

--- a/src/main/kotlin/com/sight/repository/ApplicationCommentRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ApplicationCommentRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ApplicationCommentRepository : JpaRepository<ApplicationComment, String>
+interface ApplicationCommentRepository : JpaRepository<ApplicationComment, String> {
+    fun findAllByApplicationFormId(applicationFormId: String): List<ApplicationComment>
+}

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -21,6 +21,7 @@ import com.sight.repository.ApplicationFormRepository
 import com.sight.repository.ApplicationQuestionRepository
 import com.sight.repository.InterviewAvailableTimeRepository
 import com.sight.repository.MemberRepository
+import com.sight.service.dto.ApplicationFormDetailDto
 import com.sight.service.dto.ApplicationFormDraftDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -61,6 +62,17 @@ class ApplicationFormService(
             )
 
         return applicationCommentRepository.save(comment)
+    }
+
+    @Transactional(readOnly = true)
+    fun getDetail(applicationFormId: String): ApplicationFormDetailDto {
+        val form = applicationFormRepository.findById(applicationFormId).orElseThrow { NotFoundException("가입신청서를 찾을 수 없습니다") }
+        return ApplicationFormDetailDto(
+            form,
+            applicationContentRepository.findAllByApplicationFormId(applicationFormId),
+            interviewAvailableTimeRepository.findAllByApplicationFormId(applicationFormId),
+            applicationCommentRepository.findAllByApplicationFormId(applicationFormId),
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/com/sight/service/dto/ApplicationFormDetailDto.kt
+++ b/src/main/kotlin/com/sight/service/dto/ApplicationFormDetailDto.kt
@@ -1,0 +1,13 @@
+package com.sight.service.dto
+
+import com.sight.domain.application.ApplicationComment
+import com.sight.domain.application.ApplicationContent
+import com.sight.domain.application.ApplicationForm
+import com.sight.domain.application.InterviewAvailableTime
+
+data class ApplicationFormDetailDto(
+    val form: ApplicationForm,
+    val contents: List<ApplicationContent>,
+    val times: List<InterviewAvailableTime>,
+    val comments: List<ApplicationComment>,
+)

--- a/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/ApplicationFormServiceTest.kt
@@ -124,6 +124,34 @@ class ApplicationFormServiceTest {
     }
 
     @Test
+    fun `getDetail은 신청서와 답변과 면접 가능 시간과 댓글을 함께 반환한다`() {
+        val formId = "form-1"
+        val form = ApplicationForm(formId, "info21", "홍길동", ApplicationFormStatus.SUBMITTED)
+        val content = ApplicationContent("content-1", formId, "question-1", "지원 내용")
+        val time = InterviewAvailableTime("time-1", formId, "2026-06-01 10:00")
+        val comment = ApplicationComment("comment-1", formId, 1L, "검토 완료")
+        given(applicationFormRepository.findById(formId)).willReturn(Optional.of(form))
+        given(applicationContentRepository.findAllByApplicationFormId(formId)).willReturn(listOf(content))
+        given(interviewAvailableTimeRepository.findAllByApplicationFormId(formId)).willReturn(listOf(time))
+        given(applicationCommentRepository.findAllByApplicationFormId(formId)).willReturn(listOf(comment))
+
+        val result = service.getDetail(formId)
+
+        assertEquals(form, result.form)
+        assertEquals(listOf(content), result.contents)
+        assertEquals(listOf(time), result.times)
+        assertEquals(listOf(comment), result.comments)
+    }
+
+    @Test
+    fun `getDetail은 존재하지 않는 가입 신청서면 NotFoundException을 던진다`() {
+        given(applicationFormRepository.findById("missing-form")).willReturn(Optional.empty())
+
+        assertThrows<NotFoundException> { service.getDetail("missing-form") }
+        verify(applicationContentRepository, never()).findAllByApplicationFormId(any())
+    }
+
+    @Test
     fun `createDraft는 Info21 인증 실패 시 UnauthorizedException을 던진다`() {
         given(info21AuthClient.authenticate(any()))
             .willReturn(stuauthResponse(code = 401))


### PR DESCRIPTION
1. 주어진 `ApplicationFormId`에 해당하는 `ApplicationContent`를 조회한다. 만약 `ApplicationFormId`에 해당하는 `ApplicationContent`가 없다면 404.
2.

### Query Parameters
- ApplicationFormId: string

### Request Body
- (없음)

### Status Code
- 200

### Response Body
- ApplicationForm: object
	- id: string
	- applicationFormId: string
	- questionId: string
	- content: text
	- createdAt: datetime
	- updatedAt: datetime
	- availableAt: string
