### PR TITLE
feat: 회원 등록 요청 삭제 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/UserRegistrationRequestController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/UserRegistrationRequestController.kt
@@ -11,6 +11,7 @@ import com.sight.core.exception.BadRequestException
 import com.sight.service.UserRegistrationRequestService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -22,6 +23,15 @@ import org.springframework.web.bind.annotation.RestController
 class UserRegistrationRequestController(
     private val userRegistrationRequestService: UserRegistrationRequestService,
 ) {
+    @Auth([UserRole.MANAGER])
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/manager/user-registration-requests/{requestId}")
+    fun delete(
+        @PathVariable requestId: String,
+    ) {
+        userRegistrationRequestService.delete(requestId)
+    }
+
     @Auth([UserRole.MANAGER])
     @PutMapping("/manager/user-registration-requests/{requestId}")
     fun updateStatus(

--- a/src/main/kotlin/com/sight/service/UserRegistrationRequestService.kt
+++ b/src/main/kotlin/com/sight/service/UserRegistrationRequestService.kt
@@ -22,6 +22,15 @@ class UserRegistrationRequestService(
     private val info21AuthClient: Info21AuthClient,
 ) {
     @Transactional
+    fun delete(requestId: String) {
+        val request =
+            userRegistrationRequestRepository.findById(requestId).orElseThrow {
+                NotFoundException("회원 등록 요청을 찾을 수 없습니다")
+            }
+        userRegistrationRequestRepository.delete(request)
+    }
+
+    @Transactional
     fun approve(requestId: String): UserRegistrationRequest {
         val userRegistrationRequest =
             userRegistrationRequestRepository.findById(requestId).orElseThrow {

--- a/src/test/kotlin/com/sight/service/UserRegistrationRequestServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/UserRegistrationRequestServiceTest.kt
@@ -216,6 +216,39 @@ class UserRegistrationRequestServiceTest {
         verify(userRegistrationRequestRepository).findById(requestId)
     }
 
+    @Test
+    fun `delete는 회원 등록 요청을 삭제한다`() {
+        // given
+        val requestId = "registration-request-id"
+        val request =
+            UserRegistrationRequest(
+                id = requestId,
+                requestedUserId = 1L,
+                status = UserRegistrationRequestStatus.PENDING,
+            )
+        whenever(userRegistrationRequestRepository.findById(requestId)).thenReturn(Optional.of(request))
+
+        // when
+        userRegistrationRequestService.delete(requestId)
+
+        // then
+        verify(userRegistrationRequestRepository).delete(request)
+    }
+
+    @Test
+    fun `delete는 회원 등록 요청이 없으면 NotFoundException을 발생시킨다`() {
+        // given
+        val requestId = "missing-request-id"
+        whenever(userRegistrationRequestRepository.findById(requestId)).thenReturn(Optional.empty())
+
+        // when & then
+        assertThrows<NotFoundException> {
+            userRegistrationRequestService.delete(requestId)
+        }
+
+        verify(userRegistrationRequestRepository, never()).delete(any())
+    }
+
     private fun stuauthResponse(
         code: Int = 200,
         name: String = "LOCAL_USER",


### PR DESCRIPTION
1. 회원 등록 요청 id가 존재하는 지 확인한다. 없다면 404.
2. 회원 등록 요청 id를 통해 해당 `UserRegestrationRequest`를 삭제한다.

### Query Parameters
- (없음)

### Request Body
- (없음)

### Status Code
- 200

### Response Body
- content: “삭제되었습니다”
