### PR TITLE
feat: 운영진 가입신청서 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -6,6 +6,7 @@ import com.sight.controllers.http.dto.CreateApplicationCommentResponse
 import com.sight.controllers.http.dto.CreateApplicationFormDraftRequest
 import com.sight.controllers.http.dto.CreateApplicationFormDraftResponse
 import com.sight.controllers.http.dto.GetApplicationFormDetailResponse
+import com.sight.controllers.http.dto.ListApplicationFormsResponse
 import com.sight.controllers.http.dto.SaveApplicationFormDraftRequest
 import com.sight.controllers.http.dto.SubmitApplicationFormRequest
 import com.sight.core.auth.Auth
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -28,6 +30,21 @@ import org.springframework.web.bind.annotation.RestController
 class ApplicationFormController(
     private val applicationFormService: ApplicationFormService,
 ) {
+    @Auth([UserRole.MANAGER])
+    @GetMapping("/manager/application-forms")
+    fun listForms(
+        @RequestParam(defaultValue = "1") page: Int,
+    ): ListApplicationFormsResponse {
+        val forms = applicationFormService.listForms(page)
+        return ListApplicationFormsResponse(
+            forms.content.map {
+                ListApplicationFormsResponse.Application(it.id, it.submittee, it.status, it.assignedUserId, it.createdAt, it.updatedAt)
+            },
+            forms.totalElements,
+            forms.totalPages,
+        )
+    }
+
     @Auth([UserRole.MANAGER])
     @GetMapping("/manager/application-forms/{applicationFormId}")
     fun getDetail(

--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -47,7 +47,6 @@ class ApplicationFormController(
                 ListApplicationFormsResponse.Application(it.id, it.submittee, it.status, it.assignedUserId, it.createdAt, it.updatedAt)
             },
             forms.totalElements,
-            forms.totalPages,
         )
     }
 

--- a/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/ApplicationFormController.kt
@@ -14,6 +14,7 @@ import com.sight.core.auth.Requester
 import com.sight.core.auth.UserRole
 import com.sight.service.ApplicationFormService
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
 
 @RestController
 class ApplicationFormController(
@@ -34,8 +36,12 @@ class ApplicationFormController(
     @GetMapping("/manager/application-forms")
     fun listForms(
         @RequestParam(defaultValue = "1") page: Int,
+        @RequestParam(required = false) interviewTime: List<String>?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        date: LocalDateTime?,
     ): ListApplicationFormsResponse {
-        val forms = applicationFormService.listForms(page)
+        val forms = applicationFormService.listForms(page, interviewTime ?: emptyList(), date)
         return ListApplicationFormsResponse(
             forms.content.map {
                 ListApplicationFormsResponse.Application(it.id, it.submittee, it.status, it.assignedUserId, it.createdAt, it.updatedAt)

--- a/src/main/kotlin/com/sight/controllers/http/dto/ListApplicationFormsResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/ListApplicationFormsResponse.kt
@@ -5,8 +5,7 @@ import java.time.LocalDateTime
 
 data class ListApplicationFormsResponse(
     val applications: List<Application>,
-    val totalCount: Long,
-    val totalPages: Int,
+    val count: Long,
 ) {
     data class Application(
         val id: String,

--- a/src/main/kotlin/com/sight/controllers/http/dto/ListApplicationFormsResponse.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/ListApplicationFormsResponse.kt
@@ -1,0 +1,19 @@
+package com.sight.controllers.http.dto
+
+import com.sight.domain.application.ApplicationFormStatus
+import java.time.LocalDateTime
+
+data class ListApplicationFormsResponse(
+    val applications: List<Application>,
+    val totalCount: Long,
+    val totalPages: Int,
+) {
+    data class Application(
+        val id: String,
+        val submittee: String,
+        val status: ApplicationFormStatus,
+        val assignedUserId: Long?,
+        val createdAt: LocalDateTime,
+        val updatedAt: LocalDateTime,
+    )
+}

--- a/src/main/kotlin/com/sight/repository/ApplicationFormRepository.kt
+++ b/src/main/kotlin/com/sight/repository/ApplicationFormRepository.kt
@@ -2,9 +2,29 @@ package com.sight.repository
 
 import com.sight.domain.application.ApplicationForm
 import com.sight.domain.application.ApplicationFormStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface ApplicationFormRepository : JpaRepository<ApplicationForm, String> {
+    @Query(
+        "select distinct form from ApplicationForm form join InterviewAvailableTime time on time.applicationFormId = form.id " +
+            "where (:date is null or form.createdAt >= :date) and time.availableAt in :interviewTimes",
+    )
+    fun findAllByInterviewTimes(
+        @Param("date") date: LocalDateTime?,
+        @Param("interviewTimes") interviewTimes: List<String>,
+        pageable: Pageable,
+    ): Page<ApplicationForm>
+
+    fun findAllByCreatedAtGreaterThanEqual(
+        createdAt: LocalDateTime,
+        pageable: Pageable,
+    ): Page<ApplicationForm>
+
     fun findFirstByInfo21IdAndStatusInOrderByUpdatedAtDesc(
         info21Id: String,
         statuses: Collection<ApplicationFormStatus>,

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -77,7 +77,20 @@ class ApplicationFormService(
     }
 
     @Transactional(readOnly = true)
-    fun listForms(page: Int) = applicationFormRepository.findAll(PageRequest.of(page.coerceAtLeast(1) - 1, 20))
+    fun listForms(
+        page: Int,
+        interviewTimes: List<String>,
+        date: LocalDateTime?,
+    ) = when {
+        interviewTimes.isNotEmpty() ->
+            applicationFormRepository.findAllByInterviewTimes(
+                date,
+                interviewTimes,
+                PageRequest.of(page.coerceAtLeast(1) - 1, 20),
+            )
+        date != null -> applicationFormRepository.findAllByCreatedAtGreaterThanEqual(date, PageRequest.of(page.coerceAtLeast(1) - 1, 20))
+        else -> applicationFormRepository.findAll(PageRequest.of(page.coerceAtLeast(1) - 1, 20))
+    }
 
     @Transactional
     fun createDraft(

--- a/src/main/kotlin/com/sight/service/ApplicationFormService.kt
+++ b/src/main/kotlin/com/sight/service/ApplicationFormService.kt
@@ -23,6 +23,7 @@ import com.sight.repository.InterviewAvailableTimeRepository
 import com.sight.repository.MemberRepository
 import com.sight.service.dto.ApplicationFormDetailDto
 import com.sight.service.dto.ApplicationFormDraftDto
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.security.SecureRandom
@@ -74,6 +75,9 @@ class ApplicationFormService(
             applicationCommentRepository.findAllByApplicationFormId(applicationFormId),
         )
     }
+
+    @Transactional(readOnly = true)
+    fun listForms(page: Int) = applicationFormRepository.findAll(PageRequest.of(page.coerceAtLeast(1) - 1, 20))
 
     @Transactional
     fun createDraft(

--- a/src/test/kotlin/com/sight/controllers/http/ApplicationFormControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/ApplicationFormControllerTest.kt
@@ -17,11 +17,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -120,6 +123,35 @@ class ApplicationFormControllerTest {
                 .content(objectMapper.writeValueAsString(requestDto)),
         )
             .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `운영진 가입 신청서 목록 조회 API는 applications와 count를 반환한다`() {
+        // given
+        val managerRequester = Requester(userId = 12345L, role = UserRole.MANAGER)
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(
+                managerRequester,
+                null,
+                listOf(SimpleGrantedAuthority("ROLE_MANAGER")),
+            )
+        val form =
+            ApplicationForm(
+                id = "form-ulid",
+                info21Id = "info21-id",
+                submittee = "홍길동",
+                status = ApplicationFormStatus.SUBMITTED,
+            )
+        given(applicationFormService.listForms(1, emptyList(), null))
+            .willReturn(PageImpl(listOf(form), PageRequest.of(0, 20), 1))
+
+        // when & then
+        mockMvc.perform(get("/manager/application-forms"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.count").value(1))
+            .andExpect(jsonPath("$.applications[0].id").value("form-ulid"))
+
+        verify(applicationFormService).listForms(1, emptyList(), null)
     }
 
     @Test


### PR DESCRIPTION
1. `createdAt`이 `date`(해당 학기 부원 모집일) 보다 이전인 `applications`을 제외한다.
2. 만약 Query Parameter에서 `InterviewTime`이 존재하지 않으면, 1번에서 제외되지 않은 모든 `applications`를 쿼리한다.
3. 2번이 아니라면, `availableAt`과 `InterviewTime`의 요소가 하나 이상 일치하는 `applications`를 쿼리한다.

<details>
<summary>`InterviewAvailableTime`에서 아래와 같이 쿼리한다.</summary>

```sql
availableAt IN ('2026-05-25 13:00', '2026-05-25 20:00', ...)
```
</details>

4. 위 조건을 만족하는 `applications`의 총 개수를 `count`라고 한다.
5. `page`의 limit=20이고 offset = (page - 1) * limit으로 쿼리한다. `page`값이 있다면 해당하는 `applications`를 불러온다. Query Parameter에서 `page`값이 없거나 1미만이면 `page` = 1로 간주한다.
6. 위 조건에 맞는 `applications`가 없다면 빈 리스트를 반환한다.

---

### Query Parameters

- interviewTime: string[] (KST, format: YYYY-MM-DD HH:mm)
- date: datetime
- page: int

### Request Body

- (없음)

### Status Code

- 200

### Response Body

- applications: object[]
  - id: string
  - submittee: string
  - status: string
  - assignedUserId: bigint
  - createdAt: datetime
  - updatedAt: datetime
- count: int