### PR TITLE
feat: 운영진 문자 발송 API 구현

### DIFF
--- a/src/main/kotlin/com/sight/config/SolapiConfig.kt
+++ b/src/main/kotlin/com/sight/config/SolapiConfig.kt
@@ -1,0 +1,33 @@
+package com.sight.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestTemplate
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "solapi")
+data class SolapiProperties(
+    val apiKey: String = "",
+    val apiSecret: String = "",
+    val baseUrl: String = "https://api.solapi.com",
+    val timeout: Duration = Duration.ofSeconds(10),
+)
+
+@Configuration
+@EnableConfigurationProperties(SolapiProperties::class)
+class SolapiConfig(
+    private val properties: SolapiProperties,
+) {
+    @Bean
+    fun solapiRestTemplate(): RestTemplate {
+        val requestFactory =
+            SimpleClientHttpRequestFactory().apply {
+                setConnectTimeout(properties.timeout)
+                setReadTimeout(properties.timeout)
+            }
+        return RestTemplate(requestFactory)
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/SenderPhoneController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/SenderPhoneController.kt
@@ -1,0 +1,32 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.GetSenderPhoneResponse
+import com.sight.controllers.http.dto.UpdateSenderPhoneRequest
+import com.sight.core.auth.Auth
+import com.sight.core.auth.UserRole
+import com.sight.service.SenderPhoneService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class SenderPhoneController(
+    private val senderPhoneService: SenderPhoneService,
+) {
+    @Auth([UserRole.MANAGER])
+    @GetMapping("/manager/sender-phone")
+    fun getSenderPhone(): GetSenderPhoneResponse = GetSenderPhoneResponse(phone = senderPhoneService.getSenderPhone())
+
+    @Auth([UserRole.MANAGER])
+    @PutMapping("/manager/sender-phone")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun updateSenderPhone(
+        @Valid @RequestBody request: UpdateSenderPhoneRequest,
+    ) {
+        senderPhoneService.updateSenderPhone(checkNotNull(request.phone))
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/SmsMessageController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/SmsMessageController.kt
@@ -18,11 +18,11 @@ class SmsMessageController(
 ) {
     @Auth([UserRole.MANAGER])
     @PostMapping("/manager/sms-messages")
-    fun createSmsMessages(
+    fun sendSmsMessages(
         @Valid @RequestBody request: CreateSmsMessageRequest,
     ): ResponseEntity<CreateSmsMessageResponse> {
         val result =
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 memberIds = checkNotNull(request.memberIds).filterNotNull(),
                 additionalPhoneNumbers = checkNotNull(request.additionalPhoneNumbers).filterNotNull(),
                 message = checkNotNull(request.message),

--- a/src/main/kotlin/com/sight/controllers/http/SmsMessageController.kt
+++ b/src/main/kotlin/com/sight/controllers/http/SmsMessageController.kt
@@ -1,0 +1,33 @@
+package com.sight.controllers.http
+
+import com.sight.controllers.http.dto.CreateSmsMessageRequest
+import com.sight.controllers.http.dto.CreateSmsMessageResponse
+import com.sight.core.auth.Auth
+import com.sight.core.auth.UserRole
+import com.sight.service.SmsMessageService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class SmsMessageController(
+    private val smsMessageService: SmsMessageService,
+) {
+    @Auth([UserRole.MANAGER])
+    @PostMapping("/manager/sms-messages")
+    fun createSmsMessages(
+        @Valid @RequestBody request: CreateSmsMessageRequest,
+    ): ResponseEntity<CreateSmsMessageResponse> {
+        val result =
+            smsMessageService.createSmsMessages(
+                memberIds = checkNotNull(request.memberIds).filterNotNull(),
+                additionalPhoneNumbers = checkNotNull(request.additionalPhoneNumbers).filterNotNull(),
+                message = checkNotNull(request.message),
+            )
+        val status = if (result.hasFailures) HttpStatus.UNPROCESSABLE_ENTITY else HttpStatus.OK
+        return ResponseEntity.status(status).body(CreateSmsMessageResponse.from(result))
+    }
+}

--- a/src/main/kotlin/com/sight/controllers/http/dto/SenderPhoneDto.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/SenderPhoneDto.kt
@@ -1,0 +1,12 @@
+package com.sight.controllers.http.dto
+
+import jakarta.validation.constraints.NotNull
+
+data class GetSenderPhoneResponse(
+    val phone: String,
+)
+
+data class UpdateSenderPhoneRequest(
+    @field:NotNull(message = "동아리 공식 발신번호는 필수입니다")
+    val phone: String?,
+)

--- a/src/main/kotlin/com/sight/controllers/http/dto/SmsMessageDto.kt
+++ b/src/main/kotlin/com/sight/controllers/http/dto/SmsMessageDto.kt
@@ -1,0 +1,51 @@
+package com.sight.controllers.http.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.sight.service.CreateSmsMessagesResult
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class CreateSmsMessageRequest(
+    @field:NotNull(message = "회원 수신자 목록은 필수입니다")
+    val memberIds: List<Long?>?,
+    @field:NotNull(message = "직접 지정 전화번호 목록은 필수입니다")
+    val additionalPhoneNumbers: List<String?>?,
+    @field:NotBlank(message = "문자 메시지 내용은 공백일 수 없습니다")
+    val message: String?,
+) {
+    @get:JsonIgnore
+    @get:AssertTrue(message = "수신자 목록에 null을 포함할 수 없습니다")
+    val hasNoNullRecipient: Boolean
+        get() =
+            memberIds?.none { it == null } != false &&
+                additionalPhoneNumbers?.none { it == null } != false
+}
+
+data class CreateSmsMessageResponse(
+    val results: List<SmsMessageResultResponse>,
+) {
+    companion object {
+        fun from(result: CreateSmsMessagesResult): CreateSmsMessageResponse =
+            CreateSmsMessageResponse(
+                results =
+                    result.results.map {
+                        SmsMessageResultResponse(
+                            memberId = it.memberId,
+                            phone = it.phone,
+                            type = it.type?.name,
+                            status = it.status.name,
+                            message = it.message,
+                        )
+                    },
+            )
+    }
+}
+
+data class SmsMessageResultResponse(
+    val memberId: Long?,
+    val phone: String?,
+    val type: String?,
+    val status: String,
+    val message: String?,
+)

--- a/src/main/kotlin/com/sight/core/config/ConfigKey.kt
+++ b/src/main/kotlin/com/sight/core/config/ConfigKey.kt
@@ -24,4 +24,8 @@ enum class ConfigKey(
         defaultValue = "",
         description = "도서 스캔 허용 IP(동방 공유기의 외부 IP)",
     ),
+    SMS_SENDER_PHONE(
+        defaultValue = "",
+        description = "문자 발송에 사용하는 동아리 공식 전화번호",
+    ),
 }

--- a/src/main/kotlin/com/sight/core/config/SystemConfigRegistry.kt
+++ b/src/main/kotlin/com/sight/core/config/SystemConfigRegistry.kt
@@ -54,6 +54,14 @@ class SystemConfigRegistry(
     }
 
     /**
+     * 인스턴스 내부 캐시를 사용하지 않고 저장소의 최신 설정 값을 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    fun getFreshValue(key: ConfigKey): String {
+        return systemConfigRepository.findByConfigKey(key)?.configValue ?: key.defaultValue
+    }
+
+    /**
      * 설정 값을 Boolean으로 파싱하여 반환합니다.
      */
     fun getValueAsBoolean(key: ConfigKey): Boolean {

--- a/src/main/kotlin/com/sight/domain/sms/SmsMessage.kt
+++ b/src/main/kotlin/com/sight/domain/sms/SmsMessage.kt
@@ -1,0 +1,37 @@
+package com.sight.domain.sms
+
+enum class SmsMessageType {
+    SMS,
+    LMS,
+}
+
+data class SmsMessage private constructor(
+    val text: String,
+    val type: SmsMessageType,
+) {
+    companion object {
+        private const val SMS_MAX_BYTES = 90
+        private const val REALNAME_PLACEHOLDER = "{realname}"
+
+        fun personalize(
+            template: String,
+            recipientName: String,
+        ): SmsMessage {
+            val text = template.replace(REALNAME_PLACEHOLDER, recipientName)
+            val type = if (byteCount(text) <= SMS_MAX_BYTES) SmsMessageType.SMS else SmsMessageType.LMS
+            return SmsMessage(text = text, type = type)
+        }
+
+        fun byteCount(text: String): Int =
+            text.fold(0) { total, character ->
+                total + if (character.code <= 0x7F) 1 else 2
+            }
+    }
+}
+
+object PhoneNumberNormalizer {
+    fun normalize(phone: String?): String =
+        phone
+            .orEmpty()
+            .filter { it in '0'..'9' }
+}

--- a/src/main/kotlin/com/sight/service/SenderPhoneService.kt
+++ b/src/main/kotlin/com/sight/service/SenderPhoneService.kt
@@ -1,0 +1,40 @@
+package com.sight.service
+
+import com.sight.core.config.ConfigKey
+import com.sight.core.config.SystemConfigRegistry
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.InternalServerErrorException
+import com.sight.core.exception.NotFoundException
+import com.sight.domain.sms.PhoneNumberNormalizer
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SenderPhoneService(
+    private val systemConfigRegistry: SystemConfigRegistry,
+) {
+    @Transactional(readOnly = true)
+    fun getSenderPhone(): String {
+        return getFreshSenderPhone().ifBlank {
+            throw NotFoundException("동아리 공식 발신번호가 설정되지 않았습니다")
+        }
+    }
+
+    @Transactional
+    fun updateSenderPhone(phone: String) {
+        val normalizedPhone = PhoneNumberNormalizer.normalize(phone)
+        if (normalizedPhone.isBlank()) {
+            throw BadRequestException("동아리 공식 발신번호에는 숫자가 포함되어야 합니다")
+        }
+        systemConfigRegistry.setValue(ConfigKey.SMS_SENDER_PHONE, normalizedPhone)
+    }
+
+    @Transactional(readOnly = true)
+    fun getSenderPhoneForSending(): String {
+        return getFreshSenderPhone().ifBlank {
+            throw InternalServerErrorException("동아리 공식 발신번호가 설정되지 않았습니다")
+        }
+    }
+
+    private fun getFreshSenderPhone(): String = systemConfigRegistry.getFreshValue(ConfigKey.SMS_SENDER_PHONE)
+}

--- a/src/main/kotlin/com/sight/service/SmsMessageService.kt
+++ b/src/main/kotlin/com/sight/service/SmsMessageService.kt
@@ -1,0 +1,173 @@
+package com.sight.service
+
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.InternalServerErrorException
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
+import com.sight.domain.sms.PhoneNumberNormalizer
+import com.sight.domain.sms.SmsMessage
+import com.sight.domain.sms.SmsMessageType
+import com.sight.repository.MemberRepository
+import com.sight.service.sms.SendSmsMessage
+import com.sight.service.sms.SmsMessageClient
+import com.sight.service.sms.SmsMessageClientException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+enum class SmsMessageResultStatus {
+    SENT,
+    FAILED,
+    SKIPPED,
+}
+
+data class SmsMessageResult(
+    val memberId: Long?,
+    val phone: String?,
+    val type: SmsMessageType?,
+    val status: SmsMessageResultStatus,
+    val message: String?,
+)
+
+data class CreateSmsMessagesResult(
+    val results: List<SmsMessageResult>,
+) {
+    val hasFailures: Boolean = results.any { it.status != SmsMessageResultStatus.SENT }
+}
+
+@Service
+class SmsMessageService(
+    private val memberRepository: MemberRepository,
+    private val senderPhoneService: SenderPhoneService,
+    private val smsMessageClient: SmsMessageClient,
+) {
+    @Transactional(readOnly = true)
+    fun createSmsMessages(
+        memberIds: List<Long>,
+        additionalPhoneNumbers: List<String>,
+        message: String,
+    ): CreateSmsMessagesResult {
+        if (message.isBlank()) {
+            throw BadRequestException("문자 메시지 내용은 공백일 수 없습니다")
+        }
+
+        val uniqueMemberIds = memberIds.distinct()
+        val membersById = memberRepository.findAllById(uniqueMemberIds).associateBy { it.id }
+        val hasInvalidMember =
+            uniqueMemberIds.any { memberId ->
+                val member = membersById[memberId]
+                member == null || member.status == UserStatus.UNAUTHORIZED || member.studentStatus == StudentStatus.UNITED
+            }
+        if (hasInvalidMember) {
+            throw BadRequestException("문자 수신자로 지정할 수 없는 회원이 포함되어 있습니다")
+        }
+
+        val plans = mutableListOf<RecipientPlan>()
+        val usedPhones = mutableSetOf<String>()
+        uniqueMemberIds.forEach { memberId ->
+            val member = checkNotNull(membersById[memberId])
+            val phone = PhoneNumberNormalizer.normalize(member.phone)
+            if (phone.isBlank()) {
+                plans += RecipientPlan.skipped(memberId)
+            } else if (usedPhones.add(phone)) {
+                plans +=
+                    RecipientPlan.sendable(
+                        memberId = memberId,
+                        phone = phone,
+                        message = SmsMessage.personalize(message, member.realname),
+                    )
+            }
+        }
+
+        additionalPhoneNumbers
+            .flatMap { it.split(',') }
+            .map(PhoneNumberNormalizer::normalize)
+            .filter { it.isNotBlank() }
+            .forEach { phone ->
+                if (usedPhones.add(phone)) {
+                    plans +=
+                        RecipientPlan.sendable(
+                            memberId = null,
+                            phone = phone,
+                            message = SmsMessage.personalize(message, phone),
+                        )
+                }
+            }
+
+        if (uniqueMemberIds.isEmpty() && plans.isEmpty()) {
+            throw BadRequestException("문자 메시지를 받을 수신자가 없습니다")
+        }
+
+        val sendablePlans = plans.filter { it.message != null }
+        if (sendablePlans.isEmpty()) {
+            return CreateSmsMessagesResult(plans.map { it.toSkippedResult() })
+        }
+
+        val senderPhone = senderPhoneService.getSenderPhoneForSending()
+        val indexedPlans = sendablePlans.mapIndexed { index, plan -> index.toString() to plan }
+        val clientResults =
+            try {
+                smsMessageClient.send(
+                    indexedPlans.map { (recipientIndex, plan) ->
+                        SendSmsMessage(
+                            recipientIndex = recipientIndex,
+                            from = senderPhone,
+                            to = checkNotNull(plan.phone),
+                            text = checkNotNull(plan.message).text,
+                            type = plan.message.type,
+                        )
+                    },
+                )
+            } catch (e: SmsMessageClientException) {
+                throw InternalServerErrorException(e.message ?: "문자 발송 서비스 요청에 실패했습니다")
+            }
+        val clientResultsByIndex = clientResults.associateBy { it.recipientIndex }
+        val acceptedByPlan =
+            indexedPlans.associate { (recipientIndex, plan) ->
+                plan to checkNotNull(clientResultsByIndex[recipientIndex]).accepted
+            }
+
+        return CreateSmsMessagesResult(
+            plans.map { plan ->
+                if (plan.message == null) {
+                    plan.toSkippedResult()
+                } else {
+                    plan.toDeliveryResult(accepted = checkNotNull(acceptedByPlan[plan]))
+                }
+            },
+        )
+    }
+
+    private data class RecipientPlan(
+        val memberId: Long?,
+        val phone: String?,
+        val message: SmsMessage?,
+    ) {
+        fun toSkippedResult(): SmsMessageResult =
+            SmsMessageResult(
+                memberId = memberId,
+                phone = null,
+                type = null,
+                status = SmsMessageResultStatus.SKIPPED,
+                message = "회원에게 등록된 전화번호가 없어 발송하지 않았습니다",
+            )
+
+        fun toDeliveryResult(accepted: Boolean): SmsMessageResult =
+            SmsMessageResult(
+                memberId = memberId,
+                phone = phone,
+                type = message?.type,
+                status = if (accepted) SmsMessageResultStatus.SENT else SmsMessageResultStatus.FAILED,
+                message = if (accepted) null else "문자 발송 서비스가 수신자를 거부했습니다",
+            )
+
+        companion object {
+            fun skipped(memberId: Long): RecipientPlan = RecipientPlan(memberId = memberId, phone = null, message = null)
+
+            fun sendable(
+                memberId: Long?,
+                phone: String,
+                message: SmsMessage,
+            ): RecipientPlan = RecipientPlan(memberId = memberId, phone = phone, message = message)
+        }
+    }
+}

--- a/src/main/kotlin/com/sight/service/SmsMessageService.kt
+++ b/src/main/kotlin/com/sight/service/SmsMessageService.kt
@@ -41,7 +41,7 @@ class SmsMessageService(
     private val smsMessageClient: SmsMessageClient,
 ) {
     @Transactional(readOnly = true)
-    fun createSmsMessages(
+    fun sendSmsMessages(
         memberIds: List<Long>,
         additionalPhoneNumbers: List<String>,
         message: String,

--- a/src/main/kotlin/com/sight/service/sms/SmsMessageClient.kt
+++ b/src/main/kotlin/com/sight/service/sms/SmsMessageClient.kt
@@ -1,0 +1,24 @@
+package com.sight.service.sms
+
+import com.sight.domain.sms.SmsMessageType
+
+data class SendSmsMessage(
+    val recipientIndex: String,
+    val from: String,
+    val to: String,
+    val text: String,
+    val type: SmsMessageType,
+)
+
+data class SmsMessageClientResult(
+    val recipientIndex: String,
+    val accepted: Boolean,
+)
+
+interface SmsMessageClient {
+    fun send(messages: List<SendSmsMessage>): List<SmsMessageClientResult>
+}
+
+class SmsMessageClientException(
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/com/sight/service/sms/SolapiMessageClient.kt
+++ b/src/main/kotlin/com/sight/service/sms/SolapiMessageClient.kt
@@ -1,0 +1,154 @@
+package com.sight.service.sms
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.sight.config.SolapiProperties
+import com.sight.domain.sms.SmsMessageType
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpStatusCodeException
+import org.springframework.web.client.RestClientException
+import org.springframework.web.client.RestTemplate
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.HexFormat
+import java.util.UUID
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class SolapiMessageClient(
+    @Qualifier("solapiRestTemplate")
+    private val restTemplate: RestTemplate,
+    private val properties: SolapiProperties,
+) : SmsMessageClient {
+    private val logger = LoggerFactory.getLogger(SolapiMessageClient::class.java)
+
+    override fun send(messages: List<SendSmsMessage>): List<SmsMessageClientResult> {
+        if (messages.isEmpty()) return emptyList()
+        if (properties.apiKey.isBlank() || properties.apiSecret.isBlank()) {
+            throw SmsMessageClientException("문자 발송 서비스 인증 정보가 설정되지 않았습니다")
+        }
+
+        val headers =
+            HttpHeaders().apply {
+                contentType = MediaType.APPLICATION_JSON
+                set(HttpHeaders.AUTHORIZATION, createAuthorizationHeader(Instant.now().toString(), newSalt()))
+            }
+        val request =
+            HttpEntity(
+                SolapiSendRequest(
+                    messages = messages.map { it.toSolapiRequest() },
+                ),
+                headers,
+            )
+
+        val response =
+            try {
+                restTemplate.exchange(
+                    "${properties.baseUrl.trimEnd('/')}/messages/v4/send-many/detail",
+                    HttpMethod.POST,
+                    request,
+                    SolapiSendResponse::class.java,
+                )
+            } catch (e: HttpStatusCodeException) {
+                logger.error("SOLAPI 문자 발송 요청 실패: status={}", e.statusCode.value())
+                throw SmsMessageClientException("문자 발송 서비스 요청에 실패했습니다")
+            } catch (e: RestClientException) {
+                logger.error("SOLAPI 문자 발송 통신 실패: type={}", e.javaClass.simpleName)
+                throw SmsMessageClientException("문자 발송 서비스와 통신할 수 없습니다")
+            }
+
+        val body = response.body ?: throw SmsMessageClientException("문자 발송 서비스 응답을 확인할 수 없습니다")
+        return mapResponse(messages, body)
+    }
+
+    internal fun createAuthorizationHeader(
+        date: String,
+        salt: String,
+    ): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(properties.apiSecret.toByteArray(StandardCharsets.UTF_8), "HmacSHA256"))
+        val signature =
+            HexFormat.of().formatHex(
+                mac.doFinal((date + salt).toByteArray(StandardCharsets.UTF_8)),
+            )
+        return "HMAC-SHA256 apiKey=${properties.apiKey}, date=$date, salt=$salt, signature=$signature"
+    }
+
+    private fun newSalt(): String = UUID.randomUUID().toString().replace("-", "")
+
+    private fun SendSmsMessage.toSolapiRequest(): SolapiMessageRequest =
+        SolapiMessageRequest(
+            from = from,
+            to = to,
+            text = text,
+            type = type,
+            autoTypeDetect = false,
+            subject = if (type == SmsMessageType.LMS) LMS_SUBJECT else null,
+            customFields = mapOf(RECIPIENT_INDEX_FIELD to recipientIndex),
+        )
+
+    private fun mapResponse(
+        messages: List<SendSmsMessage>,
+        response: SolapiSendResponse,
+    ): List<SmsMessageClientResult> {
+        val acceptedIndexes = response.messageList.map { it.recipientIndex() }
+        val failedIndexes = response.failedMessageList.map { it.recipientIndex() }
+        val responseIndexes = acceptedIndexes + failedIndexes
+        val requestIndexes = messages.map { it.recipientIndex }
+
+        if (
+            requestIndexes.size != requestIndexes.toSet().size ||
+            responseIndexes.size != responseIndexes.toSet().size ||
+            responseIndexes.toSet() != requestIndexes.toSet()
+        ) {
+            throw SmsMessageClientException("문자 발송 서비스의 수신자별 응답을 확인할 수 없습니다")
+        }
+
+        val acceptedIndexSet = acceptedIndexes.toSet()
+        return requestIndexes.map { recipientIndex ->
+            SmsMessageClientResult(
+                recipientIndex = recipientIndex,
+                accepted = recipientIndex in acceptedIndexSet,
+            )
+        }
+    }
+
+    private fun SolapiMessageResult.recipientIndex(): String =
+        customFields?.get(RECIPIENT_INDEX_FIELD)
+            ?: throw SmsMessageClientException("문자 발송 서비스의 수신자 식별값을 확인할 수 없습니다")
+
+    private data class SolapiSendRequest(
+        val messages: List<SolapiMessageRequest>,
+    )
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private data class SolapiMessageRequest(
+        val from: String,
+        val to: String,
+        val text: String,
+        val type: SmsMessageType,
+        val autoTypeDetect: Boolean,
+        val subject: String?,
+        val customFields: Map<String, String>,
+    )
+
+    private data class SolapiSendResponse(
+        val messageList: List<SolapiMessageResult> = emptyList(),
+        val failedMessageList: List<SolapiMessageResult> = emptyList(),
+    )
+
+    private data class SolapiMessageResult(
+        val customFields: Map<String, String>? = null,
+    )
+
+    companion object {
+        private const val LMS_SUBJECT = "쿠러그, 경희대학교 중앙 IT 동아리"
+        private const val RECIPIENT_INDEX_FIELD = "recipientIndex"
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,12 @@ logging:
     com.sight: INFO
     org.springframework: INFO
 
+solapi:
+  api-key: ${SOLAPI_API_KEY:}
+  api-secret: ${SOLAPI_API_SECRET:}
+  base-url: ${SOLAPI_BASE_URL:https://api.solapi.com}
+  timeout: 10s
+
 ---
 spring:
   config:

--- a/src/test/kotlin/com/sight/config/SolapiConfigTest.kt
+++ b/src/test/kotlin/com/sight/config/SolapiConfigTest.kt
@@ -1,0 +1,33 @@
+package com.sight.config
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.web.client.RestTemplate
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SolapiConfigTest {
+    private val contextRunner =
+        ApplicationContextRunner()
+            .withUserConfiguration(SolapiConfig::class.java)
+            .withPropertyValues(
+                "solapi.api-key=test-api-key",
+                "solapi.api-secret=test-api-secret",
+                "solapi.base-url=https://api.solapi.test",
+                "solapi.timeout=10s",
+            )
+
+    @Test
+    fun `SOLAPI 환경 설정과 전용 RestTemplate Bean을 생성한다`() {
+        contextRunner.run { context ->
+            val properties = context.getBean(SolapiProperties::class.java)
+
+            assertEquals("test-api-key", properties.apiKey)
+            assertEquals("test-api-secret", properties.apiSecret)
+            assertEquals("https://api.solapi.test", properties.baseUrl)
+            assertEquals(Duration.ofSeconds(10), properties.timeout)
+            assertNotNull(context.getBean("solapiRestTemplate", RestTemplate::class.java))
+        }
+    }
+}

--- a/src/test/kotlin/com/sight/controllers/http/SenderPhoneControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/SenderPhoneControllerTest.kt
@@ -1,0 +1,106 @@
+package com.sight.controllers.http
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sight.controllers.http.dto.UpdateSenderPhoneRequest
+import com.sight.core.auth.AuthAspect
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
+import com.sight.service.SenderPhoneService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(
+    SenderPhoneController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class],
+)
+@Import(AuthAspect::class)
+@EnableAspectJAutoProxy
+class SenderPhoneControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    private lateinit var senderPhoneService: SenderPhoneService
+
+    @BeforeEach
+    fun setUp() {
+        authenticate(UserRole.MANAGER)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `운영진은 공식 발신번호를 조회한다`() {
+        given(senderPhoneService.getSenderPhone()).willReturn("029302266")
+
+        mockMvc.perform(get("/manager/sender-phone"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.phone").value("029302266"))
+    }
+
+    @Test
+    fun `운영진은 공식 발신번호를 변경한다`() {
+        val request = UpdateSenderPhoneRequest(phone = "02-930-2266")
+
+        mockMvc.perform(
+            put("/manager/sender-phone")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isNoContent)
+
+        verify(senderPhoneService).updateSenderPhone("02-930-2266")
+    }
+
+    @Test
+    fun `공식 발신번호가 누락되면 400 Bad Request를 반환한다`() {
+        mockMvc.perform(
+            put("/manager/sender-phone")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `일반 회원은 공식 발신번호를 조회할 수 없다`() {
+        authenticate(UserRole.USER)
+
+        mockMvc.perform(get("/manager/sender-phone"))
+            .andExpect(status().isForbidden)
+    }
+
+    private fun authenticate(role: UserRole) {
+        val requester = Requester(userId = 1L, role = role)
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(
+                requester,
+                null,
+                listOf(SimpleGrantedAuthority("ROLE_${role.name}")),
+            )
+    }
+}

--- a/src/test/kotlin/com/sight/controllers/http/SmsMessageControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/SmsMessageControllerTest.kt
@@ -1,0 +1,249 @@
+package com.sight.controllers.http
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sight.controllers.http.dto.CreateSmsMessageRequest
+import com.sight.core.auth.AuthAspect
+import com.sight.core.auth.Requester
+import com.sight.core.auth.UserRole
+import com.sight.domain.sms.SmsMessageType
+import com.sight.service.CreateSmsMessagesResult
+import com.sight.service.SmsMessageResult
+import com.sight.service.SmsMessageResultStatus
+import com.sight.service.SmsMessageService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(
+    SmsMessageController::class,
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class],
+)
+@Import(AuthAspect::class)
+@EnableAspectJAutoProxy
+class SmsMessageControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    private lateinit var smsMessageService: SmsMessageService
+
+    @BeforeEach
+    fun setUp() {
+        authenticate(UserRole.MANAGER)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `모든 수신자가 정상 접수되면 200 OK와 결과를 반환한다`() {
+        val request = request()
+        given(
+            smsMessageService.createSmsMessages(
+                request.memberIds!!.filterNotNull(),
+                request.additionalPhoneNumbers!!.filterNotNull(),
+                request.message!!,
+            ),
+        )
+            .willReturn(
+                CreateSmsMessagesResult(
+                    results =
+                        listOf(
+                            SmsMessageResult(
+                                memberId = 1L,
+                                phone = "01011112222",
+                                type = SmsMessageType.SMS,
+                                status = SmsMessageResultStatus.SENT,
+                                message = null,
+                            ),
+                        ),
+                ),
+            )
+
+        mockMvc.perform(
+            post("/manager/sms-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.results[0].memberId").value(1))
+            .andExpect(jsonPath("$.results[0].phone").value("01011112222"))
+            .andExpect(jsonPath("$.results[0].type").value("SMS"))
+            .andExpect(jsonPath("$.results[0].status").value("SENT"))
+            .andExpect(jsonPath("$.results[0].message").isEmpty)
+    }
+
+    @Test
+    fun `실패하거나 건너뛴 수신자가 있으면 422와 수신자별 결과를 반환한다`() {
+        val request = request()
+        given(
+            smsMessageService.createSmsMessages(
+                request.memberIds!!.filterNotNull(),
+                request.additionalPhoneNumbers!!.filterNotNull(),
+                request.message!!,
+            ),
+        )
+            .willReturn(
+                CreateSmsMessagesResult(
+                    results =
+                        listOf(
+                            SmsMessageResult(
+                                memberId = 1L,
+                                phone = null,
+                                type = null,
+                                status = SmsMessageResultStatus.SKIPPED,
+                                message = "회원에게 등록된 전화번호가 없어 발송하지 않았습니다",
+                            ),
+                        ),
+                ),
+            )
+
+        mockMvc.perform(
+            post("/manager/sms-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isUnprocessableEntity)
+            .andExpect(jsonPath("$.results[0].memberId").value(1))
+            .andExpect(jsonPath("$.results[0].phone").isEmpty)
+            .andExpect(jsonPath("$.results[0].type").isEmpty)
+            .andExpect(jsonPath("$.results[0].status").value("SKIPPED"))
+            .andExpect(jsonPath("$.results[0].message").isNotEmpty)
+    }
+
+    @Test
+    fun `필수 수신자 목록이 누락되면 400 Bad Request를 반환한다`() {
+        mockMvc.perform(
+            post("/manager/sms-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"message":"안내 메시지"}"""),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `수신자 목록 원소가 null이면 400 Bad Request를 반환한다`() {
+        mockMvc.perform(
+            post("/manager/sms-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "memberIds": [null],
+                      "additionalPhoneNumbers": [null],
+                      "message": "안내 메시지"
+                    }
+                    """.trimIndent(),
+                ),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `공백 메시지를 받으면 400 Bad Request를 반환한다`() {
+        val request = request().copy(message = "   ")
+
+        mockMvc.perform(
+            post("/manager/sms-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `일반 회원은 문자 발송을 요청할 수 없다`() {
+        authenticate(UserRole.USER)
+        val request = request()
+
+        mockMvc.perform(
+            post("/manager/sms-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `인증되지 않은 요청은 문자 발송을 요청할 수 없다`() {
+        SecurityContextHolder.getContext().authentication =
+            AnonymousAuthenticationToken(
+                "anonymous-key",
+                "anonymousUser",
+                listOf(SimpleGrantedAuthority("ROLE_ANONYMOUS")),
+            )
+        val request = request()
+
+        mockMvc.perform(
+            post("/manager/sms-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `운영진의 요청 필드를 서비스 인자로 전달한다`() {
+        val request = request()
+        given(
+            smsMessageService.createSmsMessages(
+                request.memberIds!!.filterNotNull(),
+                request.additionalPhoneNumbers!!.filterNotNull(),
+                request.message!!,
+            ),
+        )
+            .willReturn(CreateSmsMessagesResult(emptyList()))
+
+        mockMvc.perform(
+            post("/manager/sms-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+
+        verify(smsMessageService).createSmsMessages(
+            memberIds = listOf(1L),
+            additionalPhoneNumbers = listOf("010-3333-4444"),
+            message = "안녕하세요 {realname}",
+        )
+    }
+
+    private fun request(): CreateSmsMessageRequest =
+        CreateSmsMessageRequest(
+            memberIds = listOf(1L),
+            additionalPhoneNumbers = listOf("010-3333-4444"),
+            message = "안녕하세요 {realname}",
+        )
+
+    private fun authenticate(role: UserRole) {
+        val requester = Requester(userId = 1L, role = role)
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(
+                requester,
+                null,
+                listOf(SimpleGrantedAuthority("ROLE_${role.name}")),
+            )
+    }
+}

--- a/src/test/kotlin/com/sight/controllers/http/SmsMessageControllerTest.kt
+++ b/src/test/kotlin/com/sight/controllers/http/SmsMessageControllerTest.kt
@@ -61,7 +61,7 @@ class SmsMessageControllerTest {
     fun `모든 수신자가 정상 접수되면 200 OK와 결과를 반환한다`() {
         val request = request()
         given(
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 request.memberIds!!.filterNotNull(),
                 request.additionalPhoneNumbers!!.filterNotNull(),
                 request.message!!,
@@ -99,7 +99,7 @@ class SmsMessageControllerTest {
     fun `실패하거나 건너뛴 수신자가 있으면 422와 수신자별 결과를 반환한다`() {
         val request = request()
         given(
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 request.memberIds!!.filterNotNull(),
                 request.additionalPhoneNumbers!!.filterNotNull(),
                 request.message!!,
@@ -208,7 +208,7 @@ class SmsMessageControllerTest {
     fun `운영진의 요청 필드를 서비스 인자로 전달한다`() {
         val request = request()
         given(
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 request.memberIds!!.filterNotNull(),
                 request.additionalPhoneNumbers!!.filterNotNull(),
                 request.message!!,
@@ -223,7 +223,7 @@ class SmsMessageControllerTest {
         )
             .andExpect(status().isOk)
 
-        verify(smsMessageService).createSmsMessages(
+        verify(smsMessageService).sendSmsMessages(
             memberIds = listOf(1L),
             additionalPhoneNumbers = listOf("010-3333-4444"),
             message = "안녕하세요 {realname}",

--- a/src/test/kotlin/com/sight/core/config/SystemConfigRegistryTest.kt
+++ b/src/test/kotlin/com/sight/core/config/SystemConfigRegistryTest.kt
@@ -77,6 +77,27 @@ class SystemConfigRegistryTest {
     }
 
     @Test
+    fun `getFreshValue는 캐시 값이 있어도 DB의 최신 값을 반환한다`() {
+        val key = ConfigKey.SMS_SENDER_PHONE
+        val initialConfig =
+            SystemConfig(
+                id = "01HZ9QXXX0000000000000012",
+                configKey = key,
+                configValue = "0211111111",
+            )
+        val updatedConfig = initialConfig.copy(configValue = "0222222222")
+        whenever(systemConfigRepository.findByConfigKey(key))
+            .thenReturn(initialConfig)
+            .thenReturn(updatedConfig)
+
+        systemConfigRegistry.getValue(key)
+        val result = systemConfigRegistry.getFreshValue(key)
+
+        assertEquals("0222222222", result)
+        verify(systemConfigRepository, org.mockito.kotlin.times(2)).findByConfigKey(key)
+    }
+
+    @Test
     fun `getValueAsBoolean은 Boolean 값으로 반환한다`() {
         // given
         val key = ConfigKey.KHLUG_ACCOUNT_NUMBER

--- a/src/test/kotlin/com/sight/domain/sms/SmsMessageTest.kt
+++ b/src/test/kotlin/com/sight/domain/sms/SmsMessageTest.kt
@@ -1,0 +1,35 @@
+package com.sight.domain.sms
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class SmsMessageTest {
+    @Test
+    fun `ASCII 90바이트 메시지는 SMS이고 91바이트 메시지는 LMS이다`() {
+        assertEquals(SmsMessageType.SMS, SmsMessage.personalize("a".repeat(90), "수신자").type)
+        assertEquals(SmsMessageType.LMS, SmsMessage.personalize("a".repeat(91), "수신자").type)
+    }
+
+    @Test
+    fun `한글 45자는 SMS이고 46자는 LMS이다`() {
+        assertEquals(SmsMessageType.SMS, SmsMessage.personalize("가".repeat(45), "수신자").type)
+        assertEquals(SmsMessageType.LMS, SmsMessage.personalize("가".repeat(46), "수신자").type)
+    }
+
+    @Test
+    fun `수신자 이름을 치환한 최종 메시지로 문자 유형을 결정한다`() {
+        val message = SmsMessage.personalize("a".repeat(88) + "{realname}", "가")
+
+        assertEquals("a".repeat(88) + "가", message.text)
+        assertEquals(SmsMessageType.SMS, message.type)
+
+        val longerMessage = SmsMessage.personalize("a".repeat(89) + "{realname}", "가")
+        assertEquals(SmsMessageType.LMS, longerMessage.type)
+    }
+
+    @Test
+    fun `전화번호는 ASCII 숫자만 남겨 정규화한다`() {
+        assertEquals("01012345678", PhoneNumberNormalizer.normalize("010-1234 (5678)"))
+        assertEquals("", PhoneNumberNormalizer.normalize("전화번호 없음"))
+    }
+}

--- a/src/test/kotlin/com/sight/service/SenderPhoneServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/SenderPhoneServiceTest.kt
@@ -1,0 +1,66 @@
+package com.sight.service
+
+import com.sight.core.config.ConfigKey
+import com.sight.core.config.SystemConfigRegistry
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.InternalServerErrorException
+import com.sight.core.exception.NotFoundException
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import kotlin.test.assertEquals
+
+class SenderPhoneServiceTest {
+    private val systemConfigRegistry = mock<SystemConfigRegistry>()
+    private lateinit var senderPhoneService: SenderPhoneService
+
+    @BeforeEach
+    fun setUp() {
+        senderPhoneService = SenderPhoneService(systemConfigRegistry)
+    }
+
+    @Test
+    fun `공식 발신번호는 캐시를 사용하지 않고 최신 값을 조회한다`() {
+        given(systemConfigRegistry.getFreshValue(ConfigKey.SMS_SENDER_PHONE)).willReturn("029302266")
+
+        val result = senderPhoneService.getSenderPhone()
+
+        assertEquals("029302266", result)
+        verify(systemConfigRegistry).getFreshValue(ConfigKey.SMS_SENDER_PHONE)
+    }
+
+    @Test
+    fun `공식 발신번호가 없으면 조회 요청에 NotFoundException을 던진다`() {
+        given(systemConfigRegistry.getFreshValue(ConfigKey.SMS_SENDER_PHONE)).willReturn("")
+
+        assertThrows<NotFoundException> {
+            senderPhoneService.getSenderPhone()
+        }
+    }
+
+    @Test
+    fun `문자 발송에 사용할 공식 발신번호가 없으면 InternalServerErrorException을 던진다`() {
+        given(systemConfigRegistry.getFreshValue(ConfigKey.SMS_SENDER_PHONE)).willReturn("")
+
+        assertThrows<InternalServerErrorException> {
+            senderPhoneService.getSenderPhoneForSending()
+        }
+    }
+
+    @Test
+    fun `공식 발신번호는 숫자만 남겨 저장한다`() {
+        senderPhoneService.updateSenderPhone("02-930-2266")
+
+        verify(systemConfigRegistry).setValue(ConfigKey.SMS_SENDER_PHONE, "029302266")
+    }
+
+    @Test
+    fun `공식 발신번호에 숫자가 없으면 BadRequestException을 던진다`() {
+        assertThrows<BadRequestException> {
+            senderPhoneService.updateSenderPhone("전화번호 없음")
+        }
+    }
+}

--- a/src/test/kotlin/com/sight/service/SmsMessageServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/SmsMessageServiceTest.kt
@@ -50,7 +50,7 @@ class SmsMessageServiceTest {
         val messagesCaptor = argumentCaptor<List<SendSmsMessage>>()
 
         val result =
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 memberIds = listOf(2L, 1L, 2L),
                 additionalPhoneNumbers = listOf("010-1111-2222, 010-3333-4444", "번호 없음"),
                 message = "안녕하세요 {realname}",
@@ -74,7 +74,7 @@ class SmsMessageServiceTest {
         given(memberRepository.findAllById(listOf(1L, 999L))).willReturn(listOf(unitedMember))
 
         assertThrows<BadRequestException> {
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 memberIds = listOf(1L, 999L),
                 additionalPhoneNumbers = listOf("01012345678"),
                 message = "안내 메시지",
@@ -94,7 +94,7 @@ class SmsMessageServiceTest {
         )
 
         val result =
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 memberIds = listOf(1L),
                 additionalPhoneNumbers = emptyList(),
                 message = "안내 메시지",
@@ -110,7 +110,7 @@ class SmsMessageServiceTest {
         given(memberRepository.findAllById(listOf(1L))).willReturn(listOf(member))
 
         val result =
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 memberIds = listOf(1L),
                 additionalPhoneNumbers = emptyList(),
                 message = "안내 메시지",
@@ -127,7 +127,7 @@ class SmsMessageServiceTest {
     @Test
     fun `유효한 회원과 직접 지정 전화번호가 없으면 요청을 거부한다`() {
         assertThrows<BadRequestException> {
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 memberIds = emptyList(),
                 additionalPhoneNumbers = listOf("번호 없음", "---"),
                 message = "안내 메시지",
@@ -139,7 +139,7 @@ class SmsMessageServiceTest {
     @Test
     fun `공백 메시지는 회원 조회와 외부 발송 전에 거부한다`() {
         assertThrows<BadRequestException> {
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 memberIds = listOf(1L),
                 additionalPhoneNumbers = emptyList(),
                 message = "   ",
@@ -161,7 +161,7 @@ class SmsMessageServiceTest {
         )
 
         val result =
-            smsMessageService.createSmsMessages(
+            smsMessageService.sendSmsMessages(
                 memberIds = emptyList(),
                 additionalPhoneNumbers = listOf("01011112222", "01033334444"),
                 message = "안내 메시지",
@@ -187,7 +187,7 @@ class SmsMessageServiceTest {
         }
         val messagesCaptor = argumentCaptor<List<SendSmsMessage>>()
 
-        smsMessageService.createSmsMessages(
+        smsMessageService.sendSmsMessages(
             memberIds = listOf(1L, 2L),
             additionalPhoneNumbers = emptyList(),
             message = "a".repeat(88) + "{realname}",
@@ -206,7 +206,7 @@ class SmsMessageServiceTest {
 
         val exception =
             assertThrows<InternalServerErrorException> {
-                smsMessageService.createSmsMessages(
+                smsMessageService.sendSmsMessages(
                     memberIds = emptyList(),
                     additionalPhoneNumbers = listOf("01011112222"),
                     message = "안내 메시지",

--- a/src/test/kotlin/com/sight/service/SmsMessageServiceTest.kt
+++ b/src/test/kotlin/com/sight/service/SmsMessageServiceTest.kt
@@ -1,0 +1,234 @@
+package com.sight.service
+
+import com.sight.core.exception.BadRequestException
+import com.sight.core.exception.InternalServerErrorException
+import com.sight.domain.member.Member
+import com.sight.domain.member.StudentStatus
+import com.sight.domain.member.UserStatus
+import com.sight.domain.sms.SmsMessageType
+import com.sight.repository.MemberRepository
+import com.sight.service.sms.SendSmsMessage
+import com.sight.service.sms.SmsMessageClient
+import com.sight.service.sms.SmsMessageClientException
+import com.sight.service.sms.SmsMessageClientResult
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SmsMessageServiceTest {
+    private val memberRepository = mock<MemberRepository>()
+    private val senderPhoneService = mock<SenderPhoneService>()
+    private val smsMessageClient = mock<SmsMessageClient>()
+    private lateinit var smsMessageService: SmsMessageService
+
+    @BeforeEach
+    fun setUp() {
+        smsMessageService = SmsMessageService(memberRepository, senderPhoneService, smsMessageClient)
+    }
+
+    @Test
+    fun `회원과 직접 지정 수신자를 정규화하고 중복 제거 후 요청 순서로 발송한다`() {
+        val firstMember = member(id = 2L, realname = "김쿠러그", phone = "010-1111-2222")
+        val duplicatedPhoneMember = member(id = 1L, realname = "이쿠러그", phone = "01011112222")
+        given(memberRepository.findAllById(listOf(2L, 1L))).willReturn(listOf(duplicatedPhoneMember, firstMember))
+        given(senderPhoneService.getSenderPhoneForSending()).willReturn("029302266")
+        given(smsMessageClient.send(any())).willAnswer { invocation ->
+            invocation.getArgument<List<SendSmsMessage>>(0).map {
+                SmsMessageClientResult(recipientIndex = it.recipientIndex, accepted = true)
+            }
+        }
+        val messagesCaptor = argumentCaptor<List<SendSmsMessage>>()
+
+        val result =
+            smsMessageService.createSmsMessages(
+                memberIds = listOf(2L, 1L, 2L),
+                additionalPhoneNumbers = listOf("010-1111-2222, 010-3333-4444", "번호 없음"),
+                message = "안녕하세요 {realname}",
+            )
+
+        verify(smsMessageClient).send(messagesCaptor.capture())
+        assertEquals(2, messagesCaptor.firstValue.size)
+        assertEquals("01011112222", messagesCaptor.firstValue[0].to)
+        assertEquals("안녕하세요 김쿠러그", messagesCaptor.firstValue[0].text)
+        assertEquals("01033334444", messagesCaptor.firstValue[1].to)
+        assertEquals("안녕하세요 01033334444", messagesCaptor.firstValue[1].text)
+        assertEquals(listOf(2L, null), result.results.map { it.memberId })
+        assertEquals(listOf("01011112222", "01033334444"), result.results.map { it.phone })
+        assertTrue(result.results.all { it.status == SmsMessageResultStatus.SENT })
+        assertFalse(result.hasFailures)
+    }
+
+    @Test
+    fun `허용되지 않는 회원이 하나라도 있으면 전체 요청을 거부한다`() {
+        val unitedMember = member(id = 1L, studentStatus = StudentStatus.UNITED)
+        given(memberRepository.findAllById(listOf(1L, 999L))).willReturn(listOf(unitedMember))
+
+        assertThrows<BadRequestException> {
+            smsMessageService.createSmsMessages(
+                memberIds = listOf(1L, 999L),
+                additionalPhoneNumbers = listOf("01012345678"),
+                message = "안내 메시지",
+            )
+        }
+        verify(senderPhoneService, never()).getSenderPhoneForSending()
+        verify(smsMessageClient, never()).send(any())
+    }
+
+    @Test
+    fun `차단 상태 회원은 현재 회원 수신자로 발송한다`() {
+        val inactiveMember = member(id = 1L, status = UserStatus.INACTIVE)
+        given(memberRepository.findAllById(listOf(1L))).willReturn(listOf(inactiveMember))
+        given(senderPhoneService.getSenderPhoneForSending()).willReturn("029302266")
+        given(smsMessageClient.send(any())).willReturn(
+            listOf(SmsMessageClientResult(recipientIndex = "0", accepted = true)),
+        )
+
+        val result =
+            smsMessageService.createSmsMessages(
+                memberIds = listOf(1L),
+                additionalPhoneNumbers = emptyList(),
+                message = "안내 메시지",
+            )
+
+        assertEquals(SmsMessageResultStatus.SENT, result.results.single().status)
+        verify(smsMessageClient).send(any())
+    }
+
+    @Test
+    fun `전화번호가 없는 회원만 지정하면 외부 발송 없이 SKIPPED 결과를 반환한다`() {
+        val member = member(id = 1L, phone = "전화번호 없음")
+        given(memberRepository.findAllById(listOf(1L))).willReturn(listOf(member))
+
+        val result =
+            smsMessageService.createSmsMessages(
+                memberIds = listOf(1L),
+                additionalPhoneNumbers = emptyList(),
+                message = "안내 메시지",
+            )
+
+        assertTrue(result.hasFailures)
+        assertEquals(SmsMessageResultStatus.SKIPPED, result.results.single().status)
+        assertNull(result.results.single().phone)
+        assertNull(result.results.single().type)
+        verify(senderPhoneService, never()).getSenderPhoneForSending()
+        verify(smsMessageClient, never()).send(any())
+    }
+
+    @Test
+    fun `유효한 회원과 직접 지정 전화번호가 없으면 요청을 거부한다`() {
+        assertThrows<BadRequestException> {
+            smsMessageService.createSmsMessages(
+                memberIds = emptyList(),
+                additionalPhoneNumbers = listOf("번호 없음", "---"),
+                message = "안내 메시지",
+            )
+        }
+        verify(smsMessageClient, never()).send(any())
+    }
+
+    @Test
+    fun `공백 메시지는 회원 조회와 외부 발송 전에 거부한다`() {
+        assertThrows<BadRequestException> {
+            smsMessageService.createSmsMessages(
+                memberIds = listOf(1L),
+                additionalPhoneNumbers = emptyList(),
+                message = "   ",
+            )
+        }
+        verify(memberRepository, never()).findAllById(any<List<Long>>())
+        verify(smsMessageClient, never()).send(any())
+    }
+
+    @Test
+    fun `SOLAPI 수신자별 결과를 원래 수신자 순서로 반환한다`() {
+        given(memberRepository.findAllById(emptyList())).willReturn(emptyList())
+        given(senderPhoneService.getSenderPhoneForSending()).willReturn("029302266")
+        given(smsMessageClient.send(any())).willReturn(
+            listOf(
+                SmsMessageClientResult(recipientIndex = "1", accepted = false),
+                SmsMessageClientResult(recipientIndex = "0", accepted = true),
+            ),
+        )
+
+        val result =
+            smsMessageService.createSmsMessages(
+                memberIds = emptyList(),
+                additionalPhoneNumbers = listOf("01011112222", "01033334444"),
+                message = "안내 메시지",
+            )
+
+        assertEquals(SmsMessageResultStatus.SENT, result.results[0].status)
+        assertNull(result.results[0].message)
+        assertEquals(SmsMessageResultStatus.FAILED, result.results[1].status)
+        assertEquals("문자 발송 서비스가 수신자를 거부했습니다", result.results[1].message)
+        assertTrue(result.hasFailures)
+    }
+
+    @Test
+    fun `치환 결과에 따라 수신자별 SMS와 LMS 유형을 전달한다`() {
+        val shortNameMember = member(id = 1L, realname = "가", phone = "01011112222")
+        val longNameMember = member(id = 2L, realname = "가가", phone = "01033334444")
+        given(memberRepository.findAllById(listOf(1L, 2L))).willReturn(listOf(shortNameMember, longNameMember))
+        given(senderPhoneService.getSenderPhoneForSending()).willReturn("029302266")
+        given(smsMessageClient.send(any())).willAnswer { invocation ->
+            invocation.getArgument<List<SendSmsMessage>>(0).map {
+                SmsMessageClientResult(recipientIndex = it.recipientIndex, accepted = true)
+            }
+        }
+        val messagesCaptor = argumentCaptor<List<SendSmsMessage>>()
+
+        smsMessageService.createSmsMessages(
+            memberIds = listOf(1L, 2L),
+            additionalPhoneNumbers = emptyList(),
+            message = "a".repeat(88) + "{realname}",
+        )
+
+        verify(smsMessageClient).send(messagesCaptor.capture())
+        assertEquals(SmsMessageType.SMS, messagesCaptor.firstValue[0].type)
+        assertEquals(SmsMessageType.LMS, messagesCaptor.firstValue[1].type)
+    }
+
+    @Test
+    fun `SOLAPI 요청 자체가 실패하면 InternalServerErrorException을 던진다`() {
+        given(memberRepository.findAllById(emptyList())).willReturn(emptyList())
+        given(senderPhoneService.getSenderPhoneForSending()).willReturn("029302266")
+        given(smsMessageClient.send(any())).willThrow(SmsMessageClientException("문자 발송 서비스와 통신할 수 없습니다"))
+
+        val exception =
+            assertThrows<InternalServerErrorException> {
+                smsMessageService.createSmsMessages(
+                    memberIds = emptyList(),
+                    additionalPhoneNumbers = listOf("01011112222"),
+                    message = "안내 메시지",
+                )
+            }
+
+        assertEquals("문자 발송 서비스와 통신할 수 없습니다", exception.message)
+    }
+
+    private fun member(
+        id: Long,
+        realname: String = "회원$id",
+        phone: String? = "01012345678",
+        studentStatus: StudentStatus = StudentStatus.UNDERGRADUATE,
+        status: UserStatus = UserStatus.ACTIVE,
+    ): Member =
+        Member(
+            id = id,
+            name = "member$id",
+            realname = realname,
+            phone = phone,
+            studentStatus = studentStatus,
+            status = status,
+        )
+}

--- a/src/test/kotlin/com/sight/service/sms/SolapiMessageClientTest.kt
+++ b/src/test/kotlin/com/sight/service/sms/SolapiMessageClientTest.kt
@@ -1,0 +1,186 @@
+package com.sight.service.sms
+
+import com.sight.config.SolapiProperties
+import com.sight.domain.sms.SmsMessageType
+import org.hamcrest.Matchers.startsWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.ExpectedCount.once
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.content
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withException
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.test.web.client.response.MockRestResponseCreators.withUnauthorizedRequest
+import org.springframework.web.client.RestTemplate
+import java.net.SocketTimeoutException
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SolapiMessageClientTest {
+    private lateinit var restTemplate: RestTemplate
+    private lateinit var server: MockRestServiceServer
+    private lateinit var client: SolapiMessageClient
+
+    @BeforeEach
+    fun setUp() {
+        restTemplate = RestTemplate()
+        server = MockRestServiceServer.bindTo(restTemplate).build()
+        client =
+            SolapiMessageClient(
+                restTemplate = restTemplate,
+                properties =
+                    SolapiProperties(
+                        apiKey = "test-api-key",
+                        apiSecret = "test-secret",
+                        baseUrl = "https://api.solapi.test",
+                    ),
+            )
+    }
+
+    @Test
+    fun `HMAC SHA256 인증 헤더를 생성한다`() {
+        val header = client.createAuthorizationHeader("2026-08-10T00:00:00Z", "fixed-salt-1234")
+
+        assertEquals(
+            "HMAC-SHA256 apiKey=test-api-key, date=2026-08-10T00:00:00Z, salt=fixed-salt-1234, " +
+                "signature=56dc0392dcdd89201568881ed0283bb520bdd3e6da9ec127685352e77b579ef4",
+            header,
+        )
+    }
+
+    @Test
+    fun `SMS와 LMS를 한 요청으로 보내고 수신자별 결과를 반환한다`() {
+        server.expect(once(), requestTo("https://api.solapi.test/messages/v4/send-many/detail"))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(header(HttpHeaders.AUTHORIZATION, startsWith("HMAC-SHA256 apiKey=test-api-key")))
+            .andExpect(
+                content().json(
+                    """
+                    {
+                      "messages": [
+                        {
+                          "from": "029302266",
+                          "to": "01011112222",
+                          "text": "단문",
+                          "type": "SMS",
+                          "autoTypeDetect": false,
+                          "customFields": {"recipientIndex": "0"}
+                        },
+                        {
+                          "from": "029302266",
+                          "to": "01033334444",
+                          "text": "장문",
+                          "type": "LMS",
+                          "autoTypeDetect": false,
+                          "subject": "쿠러그, 경희대학교 중앙 IT 동아리",
+                          "customFields": {"recipientIndex": "1"}
+                        }
+                      ]
+                    }
+                    """.trimIndent(),
+                    true,
+                ),
+            )
+            .andRespond(
+                withSuccess(
+                    """
+                    {
+                      "messageList": [
+                        {"customFields": {"recipientIndex": "0"}}
+                      ],
+                      "failedMessageList": [
+                        {"customFields": {"recipientIndex": "1"}}
+                      ]
+                    }
+                    """.trimIndent(),
+                    MediaType.APPLICATION_JSON,
+                ),
+            )
+
+        val result =
+            client.send(
+                listOf(
+                    message(recipientIndex = "0", type = SmsMessageType.SMS),
+                    message(recipientIndex = "1", type = SmsMessageType.LMS, to = "01033334444", text = "장문"),
+                ),
+            )
+
+        assertTrue(result[0].accepted)
+        assertFalse(result[1].accepted)
+        server.verify()
+    }
+
+    @Test
+    fun `수신자 식별 결과가 누락되면 요청 단위 실패로 처리한다`() {
+        server.expect(requestTo("https://api.solapi.test/messages/v4/send-many/detail"))
+            .andRespond(
+                withSuccess(
+                    """{"messageList": [], "failedMessageList": []}""",
+                    MediaType.APPLICATION_JSON,
+                ),
+            )
+
+        assertThrows<SmsMessageClientException> {
+            client.send(listOf(message(recipientIndex = "0", type = SmsMessageType.SMS)))
+        }
+    }
+
+    @Test
+    fun `SOLAPI 비정상 HTTP 응답은 요청 단위 실패로 처리한다`() {
+        server.expect(requestTo("https://api.solapi.test/messages/v4/send-many/detail"))
+            .andRespond(withUnauthorizedRequest())
+
+        assertThrows<SmsMessageClientException> {
+            client.send(listOf(message(recipientIndex = "0", type = SmsMessageType.SMS)))
+        }
+        server.verify()
+    }
+
+    @Test
+    fun `SOLAPI timeout은 자동 재시도 없이 요청 단위 실패로 처리한다`() {
+        server.expect(once(), requestTo("https://api.solapi.test/messages/v4/send-many/detail"))
+            .andRespond(withException(SocketTimeoutException("timeout")))
+
+        assertThrows<SmsMessageClientException> {
+            client.send(listOf(message(recipientIndex = "0", type = SmsMessageType.SMS)))
+        }
+        server.verify()
+    }
+
+    @Test
+    fun `인증 정보가 비어 있으면 외부 요청을 수행하지 않는다`() {
+        val unconfiguredClient =
+            SolapiMessageClient(
+                restTemplate = restTemplate,
+                properties = SolapiProperties(),
+            )
+
+        assertThrows<SmsMessageClientException> {
+            unconfiguredClient.send(listOf(message(recipientIndex = "0", type = SmsMessageType.SMS)))
+        }
+        server.verify()
+    }
+
+    private fun message(
+        recipientIndex: String,
+        type: SmsMessageType,
+        to: String = "01011112222",
+        text: String = "단문",
+    ): SendSmsMessage =
+        SendSmsMessage(
+            recipientIndex = recipientIndex,
+            from = "029302266",
+            to = to,
+            text = text,
+            type = type,
+        )
+}


### PR DESCRIPTION
## Summary

- 운영진 전용 발신번호 조회·변경 API 추가
- 회원 및 직접 지정 수신자 문자 발송 API 추가
- 수신자별 정규화·중복 제거·SMS/LMS 자동 판정 구현
- SOLAPI v4 일괄 발송 및 HMAC-SHA256 인증 연동
- 발송 도메인, 서비스, 컨트롤러, 설정, 외부 연동 테스트 추가

## Test

- `./gradlew test ktlintCheck`

실제 SOLAPI 호출과 문자 발송은 수행하지 않았습니다.